### PR TITLE
fix: explicitly state required permissions for github action

### DIFF
--- a/.github/workflows/sdk-generation.yaml
+++ b/.github/workflows/sdk-generation.yaml
@@ -1,5 +1,9 @@
 name: Speakeasy SDK Generation Workflow
-
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+  statuses: write
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
This github action requires a relatively broad set of permissions to create PRs && commit when SDKs are regenerated from a new version of the openapi specification.

Right now, when it is executed under an organisation with restricted github action permission, it can fail. This change explicitly adds required permissions such that it works under those organizations.