### PR TITLE
fix: flaky network calls on github hosted action runners

### DIFF
--- a/.github/workflows/sdk-generation.yaml
+++ b/.github/workflows/sdk-generation.yaml
@@ -158,6 +158,8 @@ jobs:
     name: Validate OpenAPI Document
     runs-on: ubuntu-latest
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: validate
         uses: speakeasy-api/sdk-generation-action@v14
         with:
@@ -208,6 +210,8 @@ jobs:
       branch_name: ${{ steps.generate.outputs.branch_name }}
       previous_gen_version: ${{ steps.generate.outputs.previous_gen_version }}
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: generate
         uses: speakeasy-api/sdk-generation-action@v14
         with:
@@ -248,6 +252,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.generate.outputs.branch_name }}
@@ -273,6 +279,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.generate.outputs.branch_name }}
@@ -300,6 +308,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.generate.outputs.branch_name }}
@@ -327,6 +337,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.generate.outputs.branch_name }}
@@ -357,6 +369,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.generate.outputs.branch_name }}
@@ -387,6 +401,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.generate.outputs.branch_name }}
@@ -414,6 +430,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.generate.outputs.branch_name }}
@@ -460,6 +478,8 @@ jobs:
     outputs:
       commit_hash: ${{ steps.finalize.outputs.commit_hash }}
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: Finalize
         uses: speakeasy-api/sdk-generation-action@v14
         with:
@@ -498,6 +518,8 @@ jobs:
       run:
         working-directory: ${{ needs.generate.outputs.python_directory }}
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.finalize.outputs.commit_hash }}
@@ -536,6 +558,8 @@ jobs:
       run:
         working-directory: ${{ needs.generate.outputs.typescript_directory }}
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.finalize.outputs.commit_hash }}
@@ -570,6 +594,8 @@ jobs:
       run:
         working-directory: ${{ needs.generate.outputs.java_directory }}
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.finalize.outputs.commit_hash }}
@@ -609,6 +635,8 @@ jobs:
       run:
         working-directory: ${{ needs.generate.outputs.ruby_directory }}
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.finalize.outputs.commit_hash }}
@@ -648,6 +676,8 @@ jobs:
       run:
         working-directory: ${{ needs.generate.outputs.php_directory }}
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - name: Publish
         uses: speakeasy-api/packagist-update@support-github-creation
         with:

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -94,6 +94,8 @@ jobs:
       ruby_regenerated: ${{ steps.release.outputs.ruby_regenerated }}
       ruby_directory: ${{ steps.release.outputs.ruby_directory }}
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: release
         uses: speakeasy-api/sdk-generation-action@v14
         with:
@@ -128,6 +130,8 @@ jobs:
       run:
         working-directory: ${{ needs.release.outputs.python_directory }}
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -164,6 +168,8 @@ jobs:
       run:
         working-directory: ${{ needs.release.outputs.typescript_directory }}
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
       - name: Set up Node
         uses: actions/setup-node@v3
@@ -196,6 +202,8 @@ jobs:
       run:
         working-directory: ${{ needs.release.outputs.java_directory }}
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
       - name: Set up Java
         uses: actions/setup-java@v3
@@ -233,6 +241,8 @@ jobs:
       run:
         working-directory: ${{ needs.release.outputs.php_directory }}
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - name: Publish
         uses: wei/curl@v1.1.1
         with:
@@ -254,6 +264,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -294,6 +306,8 @@ jobs:
       run:
         working-directory: ${{ needs.release.outputs.ruby_directory }}
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
       - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1


### PR DESCRIPTION
Add `smorimoto/tune-github-hosted-runner-network` to all jobs as a pre-step, to attempt to reduce the network problems observed on github hosted action runners.