### PR TITLE
feat: Suggestion Action Scaffold

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,6 +116,9 @@ inputs:
   write_suggestions:
       description: "Set to 'True' if you want to receive PRs with OpenAPI suggestions"
       required: false
+  openai_api_key:
+    description: "The OpenAI API key to authenticate to access LLM suggestions"
+    required: true
 outputs:
   python_regenerated:
     description: "true if the Python SDK was regenerated"
@@ -159,6 +162,7 @@ runs:
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}
+    OPENAI_API_KEY: ${{ inputs.openai_api_key }}
   args:
     - ${{ inputs.speakeasy_version }}
     - ${{ inputs.openapi_doc_location }}
@@ -179,3 +183,4 @@ runs:
     - ${{ inputs.previous_gen_version }}
     - ${{ inputs.openapi_docs }}
     - ${{ inputs.output_tests }}
+    - ${{ inputs.write_suggestions }}

--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,9 @@ inputs:
   speakeasy_server_url:
     description: "Internal use only"
     required: false
+  write_suggestions:
+      description: "Set to 'True' if you want to receive PRs with OpenAPI suggestions"
+      required: false
 outputs:
   python_regenerated:
     description: "true if the Python SDK was regenerated"

--- a/internal/actions/validate.go
+++ b/internal/actions/validate.go
@@ -42,6 +42,7 @@ func Validate() error {
 		isLocalFile = true
 	}
 
+	// We will write suggestions to a new PR if the input flag is set and we are dealing with a local OpenAPI file
 	if os.Getenv("INPUT_WRITE_SUGGESTIONS") == "true" && cli.IsAtLeastVersion(cli.LLMSuggestionVersion) && isLocalFile {
 		out, suggestionErr := cli.Suggest(docPath)
 		output := suggestions.ParseOutput(out)

--- a/internal/actions/validate.go
+++ b/internal/actions/validate.go
@@ -2,9 +2,11 @@ package actions
 
 import (
 	"fmt"
+	"github.com/speakeasy-api/sdk-generation-action/internal/git"
 	"github.com/speakeasy-api/sdk-generation-action/internal/suggestions"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/speakeasy-api/sdk-generation-action/internal/cli"
@@ -42,46 +44,54 @@ func Validate() error {
 		isLocalFile = true
 	}
 
-	// We will write suggestions to a new PR if the input flag is set and we are dealing with a local OpenAPI file
+	// We will write suggestions to a new PR if the input flag is set to true, and we are parsing a local OpenAPI file.
 	if os.Getenv("INPUT_WRITE_SUGGESTIONS") == "true" && cli.IsAtLeastVersion(cli.LLMSuggestionVersion) && isLocalFile {
 		out, suggestionErr := cli.Suggest(docPath)
-		output := suggestions.ParseOutput(out)
-		if len(output) > 0 {
-			// creates a branch for our suggestion PR
-			branch, err := g.CreateSuggestionBranch()
-			if err != nil {
-				return suggestionErr
-			}
-
-			// writes the OpenAPI doc into a new file for comments
-			file, err := createTempSuggestionFile(docPath)
-			if err != nil {
-				return suggestionErr
-			}
-
-			// commits and pushes our new OpenAPI doc
-			_, err = g.CommitAndPushSuggestions(docPath)
-			if err != nil {
-				return suggestionErr
-			}
-
-			// Creates a PR to layer OpenAPI suggestions on
-			prNumber, err := g.CreateSuggestionPR(branch)
-			if err != nil {
-				return suggestionErr
-			}
-
-			// Writes suggestion comments inline on the PR
-			if prNumber != nil {
-				g.WriteSuggestionComments(file, prNumber, output)
-			}
-
+		if err := writeSuggestions(g, out, docPath, docPathPrefix); err != nil {
+			logging.Info("error writing suggestions to PR %s", err.Error())
 		}
 
 		return suggestionErr
 	} else {
 		if err := cli.Validate(docPath); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+func writeSuggestions(g *git.Git, out string, docPath string, docPathPrefix string) error {
+	output := suggestions.ParseOutput(out)
+	if len(output) > 0 {
+		// creates a branch for our suggestion PR
+		branch, err := g.CreateSuggestionBranch()
+		if err != nil {
+			return err
+		}
+
+		// writes the OpenAPI doc into a new file for comments
+		file, err := createTempSuggestionFile(docPath)
+		if err != nil {
+			return err
+		}
+
+		// commits and pushes our new OpenAPI doc to the new branch
+		_, err = g.CommitAndPushSuggestions(strings.Replace(docPath, "repo/", "", 1))
+		if err != nil {
+			return err
+		}
+
+		// Creates a PR to layer OpenAPI suggestions on to the new branch
+		prNumber, commitSha, err := g.CreateSuggestionPR(branch, strings.Replace(docPath, "repo/", "", 1))
+		if err != nil {
+			return err
+		}
+
+		// Writes suggestion comments inline on the PR
+		if prNumber != nil {
+			fileName := strings.Replace(file, "repo/", "", 1)
+			return g.WriteSuggestionComments(fileName, prNumber, commitSha, output)
 		}
 	}
 
@@ -96,7 +106,7 @@ func createTempSuggestionFile(doc string) (string, error) {
 	}
 	defer srcFile.Close()
 
-	fileName := fmt.Sprintf("./%s-speakeasy-temp", doc)
+	fileName := strings.TrimSuffix(doc, filepath.Ext(doc)) + "-speakeasytemp" + filepath.Ext(doc)
 	dstFile, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o600)
 	if err != nil {
 		return "", fmt.Errorf("error opening releases file: %w", err)

--- a/internal/actions/validate.go
+++ b/internal/actions/validate.go
@@ -1,6 +1,10 @@
 package actions
 
 import (
+	"fmt"
+	"github.com/speakeasy-api/sdk-generation-action/internal/suggestions"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/speakeasy-api/sdk-generation-action/internal/cli"
@@ -33,9 +37,80 @@ func Validate() error {
 		logging.Debug("failed to set outputs: %v", err)
 	}
 
-	if err := cli.Validate(docPath); err != nil {
-		return err
+	isLocalFile := false
+	if _, err := os.Stat(docPath); err == nil {
+		isLocalFile = true
+	}
+
+	if os.Getenv("INPUT_WRITE_SUGGESTIONS") == "true" && cli.IsAtLeastVersion(cli.LLMSuggestionVersion) && isLocalFile {
+		out, suggestionErr := cli.Suggest(docPath)
+		output := suggestions.ParseOutput(out)
+		if len(output) > 0 {
+			// creates a branch for our suggestion PR
+			branch, err := g.CreateSuggestionBranch()
+			if err != nil {
+				return suggestionErr
+			}
+
+			// writes the OpenAPI doc into a new file for comments
+			file, err := createTempSuggestionFile(docPath)
+			if err != nil {
+				return suggestionErr
+			}
+
+			// commits and pushes our new OpenAPI doc
+			_, err = g.CommitAndPushSuggestions(docPath)
+			if err != nil {
+				return suggestionErr
+			}
+
+			// Creates a PR to layer OpenAPI suggestions on
+			prNumber, err := g.CreateSuggestionPR(branch)
+			if err != nil {
+				return suggestionErr
+			}
+
+			// Writes suggestion comments inline on the PR
+			if prNumber != nil {
+				g.WriteSuggestionComments(file, prNumber, output)
+			}
+
+		}
+
+		return suggestionErr
+	} else {
+		if err := cli.Validate(docPath); err != nil {
+			return err
+		}
 	}
 
 	return nil
+}
+
+// We need to create a temp suggestion file to layer our PR comments
+func createTempSuggestionFile(doc string) (string, error) {
+	srcFile, err := os.Open(doc)
+	if err != nil {
+		return "", err
+	}
+	defer srcFile.Close()
+
+	fileName := fmt.Sprintf("./%s-speakeasy-temp", doc)
+	dstFile, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("error opening releases file: %w", err)
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return "", err
+	}
+
+	err = dstFile.Sync()
+	if err != nil {
+		return "", err
+	}
+
+	return fileName, nil
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -15,6 +15,7 @@ var (
 	MergeVersion                   = version.Must(version.NewVersion("1.21.3"))
 	RepoDetailsVersion             = version.Must(version.NewVersion("1.23.1"))
 	OutputTestsVersion             = version.Must(version.NewVersion("1.33.2"))
+	LLMSuggestionVersion           = version.Must(version.NewVersion("1.47.1"))
 )
 
 func IsAtLeastVersion(version *version.Version) bool {
@@ -126,6 +127,15 @@ func Validate(docPath string) error {
 	}
 	fmt.Println(out)
 	return nil
+}
+
+func Suggest(docPath string) (string, error) {
+	out, err := runSpeakeasyCommand("suggest", "--schema", docPath, "--auto-approve", "--max-suggestions", "20")
+	if err != nil {
+		return out, fmt.Errorf("error suggesting openapi fixes: %w - %s", err, "")
+	}
+
+	return out, nil
 }
 
 func Generate(docPath, lang, outputDir, installationURL string, published, outputTests bool, repoURL, repoSubDirectory string) error {

--- a/internal/cli/speakeasy.go
+++ b/internal/cli/speakeasy.go
@@ -67,7 +67,7 @@ func runSpeakeasyCommand(args ...string) (string, error) {
 
 	output, err := exec.Command(cmdPath, args...).CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("error running speakeasy command: speakeasy %s - %w\n %s", strings.Join(args, " "), err, string(output))
+		return string(output), fmt.Errorf("error running speakeasy command: speakeasy %s - %w\n %s", strings.Join(args, " "), err, string(output))
 	}
 
 	return string(output), nil

--- a/internal/suggestions/suggestion.go
+++ b/internal/suggestions/suggestion.go
@@ -1,0 +1,78 @@
+package suggestions
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type GithubAnnotation struct {
+	Error       string
+	LineNumber  int
+	Suggestion  []string
+	Explanation []string
+}
+
+func ParseOutput(out string) []GithubAnnotation {
+	lines := strings.Split(out, "\n")
+	var fix, explanation []string
+	var errorMessage string
+	lineNumber := -1
+	isFix, isExplanation := false, false
+	outAnnotations := make([]GithubAnnotation, 0)
+
+	for _, line := range lines {
+		if strings.Contains(line, "[line") { // Grab line number
+			isFix, isExplanation = false, false
+			lineNumber, _ = getLineNumber(line)
+			errorMessage = line
+		} else if strings.Contains(line, "Suggested Fix:") { // Start tracking fix
+			isFix = true
+			fix = append(fix, strings.TrimPrefix(line, "Suggested Fix:"))
+			continue
+		} else if strings.Contains(line, "Explanation:") { // Start tracking explanation
+			isFix = false
+			isExplanation = true
+			explanation = append(explanation, strings.TrimPrefix(line, "Explanation:"))
+			continue
+		}
+
+		if line == "" {
+			isFix, isExplanation = false, false
+		}
+
+		if isFix { // add to fix
+			fix = append(fix, line)
+		}
+		if isExplanation { // add to explanation
+			explanation = append(explanation, line)
+		}
+
+		if !isFix && !isExplanation && len(fix) != 0 && len(explanation) != 0 && lineNumber != -1 {
+			outAnnotations = append(outAnnotations, GithubAnnotation{
+				Error:       errorMessage,
+				LineNumber:  lineNumber,
+				Suggestion:  fix,
+				Explanation: explanation,
+			})
+			fix, explanation, lineNumber, errorMessage = nil, nil, -1, ""
+		}
+	}
+
+	return outAnnotations
+}
+
+func getLineNumber(errStr string) (int, error) {
+	lineStr := strings.Split(errStr, "[line ")
+	if len(lineStr) < 2 {
+		return -1, fmt.Errorf("line number cannot be found in err %s", errStr)
+	}
+
+	lineNumStr := strings.Split(lineStr[1], "]")[0]
+	lineNum, err := strconv.Atoi(lineNumStr)
+	if err != nil {
+		return -1, err
+	}
+
+	return lineNum, nil
+}

--- a/testing/suggestion-test.sh
+++ b/testing/suggestion-test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+function run_action() {
+    rm -rf ./repo || true
+    rm ./bin/speakeasy || true
+    go run main.go
+}
+
+# Default environment variables not subject to change by different tests
+export INPUT_DEBUG=true
+export INPUT_OPENAPI_DOCS=$(cat <<EOF
+- openapi-invalid.yaml
+EOF
+)
+export SPEAKEASY_ENVIRONMENT=local
+export GITHUB_WORKSPACE="./"
+
+set -o allexport && source ./testing/suggestions.env && set +o allexport
+
+export INPUT_ACTION="validate"
+export INPUT_WRITE_SUGGESTIONS="true"
+run_action

--- a/testing/suggestions.env
+++ b/testing/suggestions.env
@@ -1,0 +1,8 @@
+export INPUT_SPEAKEASY_VERSION="latest"
+export SPEAKEASY_API_KEY=""
+export INPUT_GITHUB_ACCESS_TOKEN=""
+export GITHUB_REF="refs/heads/main"
+export GITHUB_REPOSITORY_OWNER=""
+export GITHUB_SERVER_URL="https://github.com"
+export GITHUB_REPOSITORY=""
+export GITHUB_WORKFLOW="test"


### PR DESCRIPTION
Adds LLM suggestions as a github action feature which can create a PR with suggestions.

This runs off of the validate action. The only additional variables a developer would need to add are
speakeasy CLI > 1.47.1
inputs.openai_api_key=
inputs.write_suggestions="true"