### PR TITLE
feat: add action input to change working directory for validate/generate steps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -118,7 +118,10 @@ inputs:
       required: false
   openai_api_key:
     description: "The OpenAI API key to authenticate to access LLM suggestions"
-    required: true
+    required: false
+  working_directory:
+    description: 'The working directory for the action'
+    required: false
 outputs:
   python_regenerated:
     description: "true if the Python SDK was regenerated"
@@ -184,3 +187,4 @@ runs:
     - ${{ inputs.openapi_docs }}
     - ${{ inputs.output_tests }}
     - ${{ inputs.write_suggestions }}
+    - ${{ inputs.working_directory }}

--- a/internal/actions/generate.go
+++ b/internal/actions/generate.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/speakeasy-api/sdk-generation-action/internal/cli"
 	"github.com/speakeasy-api/sdk-generation-action/internal/environment"
@@ -14,6 +15,12 @@ func Generate() error {
 	g, err := initAction()
 	if err != nil {
 		return err
+	}
+
+	if environment.GetWorkingDirectory() != "" {
+		if err := os.Chdir(environment.GetWorkingDirectory()); err != nil {
+			return err
+		}
 	}
 
 	if err := cli.Download(environment.GetPinnedSpeakeasyVersion(), g); err != nil {

--- a/internal/actions/validate.go
+++ b/internal/actions/validate.go
@@ -21,6 +21,12 @@ func Validate() error {
 		return err
 	}
 
+	if environment.GetWorkingDirectory() != "" {
+		if err := os.Chdir(environment.GetWorkingDirectory()); err != nil {
+			return err
+		}
+	}
+
 	if err := cli.Download(environment.GetPinnedSpeakeasyVersion(), g); err != nil {
 		return err
 	}

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -137,6 +137,10 @@ func GetPreviousGenVersion() string {
 	return os.Getenv("INPUT_PREVIOUS_GEN_VERSION")
 }
 
+func GetWorkingDirectory() string {
+	return os.Getenv("INPUT_WORKING_DIRECTORY")
+}
+
 func GetRepo() string {
 	return os.Getenv("GITHUB_REPOSITORY")
 }


### PR DESCRIPTION
Need to release to test.

Also, makes `OPENAI_API_KEY` optional. Didn't catch it in an earlier review, but we shouldn't require this to be passed in. 