### PR TITLE
fix: match java gpg passphrase name between actions

### DIFF
--- a/.github/workflows/sdk-generation.yaml
+++ b/.github/workflows/sdk-generation.yaml
@@ -581,7 +581,7 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.ossrh_username }}
           MAVEN_PASSWORD: ${{ secrets.ossrh_password }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.java_gpg_secret_key }}
-          ORG_GRADLE_PROJECT_signingPassphrase: ${{ secrets.java_passphrase }}
+          ORG_GRADLE_PROJECT_signingPassphrase: ${{ secrets.java_gpg_passphrase }}
       - uses: ravsamhq/notify-slack-action@v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -61,7 +61,7 @@ on:
       java_gpg_secret_key:
         description: The GPG secret key to use for signing the Java package
         required: false
-      java_passphrase:
+      java_gpg_passphrase:
         description: The passphrase for the GPG secret key
         required: false
       slack_webhook_url:
@@ -207,7 +207,7 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.ossrh_username }}
           MAVEN_PASSWORD: ${{ secrets.ossrh_password }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.java_gpg_secret_key }}
-          ORG_GRADLE_PROJECT_signingPassphrase: ${{ secrets.java_passphrase }}
+          ORG_GRADLE_PROJECT_signingPassphrase: ${{ secrets.java_gpg_passphrase }}
       - uses: ravsamhq/notify-slack-action@v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ Java publishing is supported by publishing to a staging repository provider (OSS
 - Populate the `secrets` section of the workflow file with your secrets. For example:
   - `ossrh_username: ${{ secrets.OSSRH_USERNAME }}`
   - `ossrh_password: ${{ secrets.OSSRH_PASSWORD }}`
-  - `java_gpg_secret_key: ${{ secrets.GPG_SECRET_KEY }}`
-  - `java_passphrase: ${{ secrets.GPG_PASSPHRASE }}`
+  - `java_gpg_secret_key: ${{ secrets.JAVA_GPG_SECRET_KEY }}`
+  - `java_gpg_passphrase: ${{ secrets.JAVA_GPG_PASSPHRASE }}`
 - In the workflow file, set `publish_java: true`
 - In the `java` section of `gen.yaml`, ensure the groupId you've provided matches your OSSRH org and the artifact name you want. For example:
   - `groupID: com.example`


### PR DESCRIPTION
This is necessary to properly generate workflow files