### PR TITLE
feat: limit warn/err output to 1000 each by default

### DIFF
--- a/internal/actions/validate.go
+++ b/internal/actions/validate.go
@@ -33,7 +33,18 @@ func Validate() error {
 		logging.Debug("failed to set outputs: %v", err)
 	}
 
-	if err := cli.Validate(docPath); err != nil {
+	// Errors from GetMaxValidation{Warnings,Errors} are very non-fatal, but should be logged.
+
+	var maxWarns, maxErrors int
+	if maxWarns, err = environment.GetMaxValidationWarnings(); err != nil {
+		logging.Info("%v", err)
+	}
+
+	if maxErrors, err = environment.GetMaxValidationErrors(); err != nil {
+		logging.Info("%v", err)
+	}
+
+	if err := cli.Validate(docPath, maxWarns, maxErrors); err != nil {
 		return err
 	}
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-version"
@@ -186,8 +187,12 @@ func GetChangelog(lang, genVersion, previousGenVersion string, targetVersions ma
 	}
 }
 
-func Validate(docPath string) error {
-	out, err := runSpeakeasyCommand("validate", "openapi", "-s", docPath)
+func Validate(docPath string, maxValidationWarnings, maxValidationErrors int) error {
+	var (
+		maxWarns  = strconv.Itoa(maxValidationWarnings)
+		maxErrors = strconv.Itoa(maxValidationErrors)
+	)
+	out, err := runSpeakeasyCommand("validate", "openapi", "-s", docPath, "--max-validation-warnings", maxWarns, "--max-validation-errors", maxErrors)
 	if err != nil {
 		return fmt.Errorf("error validating openapi: %w - %s", err, out)
 	}

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -3,6 +3,7 @@ package environment
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -23,6 +24,11 @@ const (
 	ActionFinalize           Action = "finalize"
 	ActionFinalizeSuggestion Action = "finalize-suggestion"
 	ActionRelease            Action = "release"
+)
+
+const (
+	DefaultMaxValidationWarnings = 1000
+	DefaultMaxValidationErrors   = 1000
 )
 
 var (
@@ -73,6 +79,34 @@ func GetPinnedSpeakeasyVersion() string {
 
 func GetMaxSuggestions() string {
 	return os.Getenv("INPUT_MAX_SUGGESTIONS")
+}
+
+func GetMaxValidationWarnings() (int, error) {
+	maxVal := os.Getenv("INPUT_MAX_VALIDATION_WARNINGS")
+	if maxVal == "" {
+		return DefaultMaxValidationWarnings, nil
+	}
+
+	maxWarns, err := strconv.Atoi(maxVal)
+	if err != nil {
+		return DefaultMaxValidationWarnings, fmt.Errorf("max_validation_warnings must be an integer, falling back to default (%d): %w", DefaultMaxValidationWarnings, err)
+	}
+
+	return maxWarns, nil
+}
+
+func GetMaxValidationErrors() (int, error) {
+	maxVal := os.Getenv("INPUT_MAX_VALIDATION_ERRORS")
+	if maxVal == "" {
+		return DefaultMaxValidationErrors, nil
+	}
+
+	maxErrors, err := strconv.Atoi(maxVal)
+	if err != nil {
+		return DefaultMaxValidationErrors, fmt.Errorf("max_validaiton_errors must be an integer, falling back to default (%d): %v", DefaultMaxValidationErrors, err)
+	}
+
+	return maxErrors, nil
 }
 
 func GetOpenAPIDocLocation() string {


### PR DESCRIPTION
The limits are user-configurable via INPUT_MAX_VALIDATION_WARNINGS and INPUT_MAX_VALIDATION_ERRORS inputs.