### PR TITLE
fix: detect significant changes in `.go` files

### DIFF
--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -40,6 +40,7 @@ index b26db52..fdc01f4 100755
 -               _sdkVersion: "1.3.0",
 +               _sdkVersion: "1.3.1",
                 _genVersion: "1.12.7",
++               _userAgent: "speakeasy-sdk/go 0.0.1 2.155.1 0.1.0-alpha openapi"
         }
         for _, opt := range opts {
 `,
@@ -73,6 +74,38 @@ index b26db52..fdc01f4 100755
                 _genVersion: "1.12.7",
         }
         for _, opt := range opts {
+`,
+			},
+			want: true,
+		},
+		{
+			name: "detects significant changes with tabs for spacing",
+			args: args{
+				// Important: Preserve tabs in the follow diff
+				diff: `diff --git a/gen.yaml b/gen.yaml
+index 322c845..585bc5b 100644
+--- a/gen.yaml
++++ b/gen.yaml
+@@ -9,5 +9,5 @@ generation:
+   sdkClassName: SDK
+   sdkFlattening: false
+ go:
+-  version: 1.3.0
++  version: 1.3.1
+   packageName: github.com/speakeasy-api/sdk-generation-action-test-repo
+diff --git a/sdk.go b/sdk.go
+index b26db52..fdc01f4 100755
+--- a/sdk.go
++++ b/sdk.go
+@@ -120,7 +120,7 @@ func WithSecurity(security shared.Security) SDKOption {
+ func New(opts ...SDKOption) *SDK {
+				sdk := &SDK{
+-								language:   "go",
++								_language:   "crazygo",
+								_sdkVersion: "1.3.0",
+								_genVersion: "1.12.7",
+				}
+				for _, opt := range opts {
 `,
 			},
 			want: true,


### PR DESCRIPTION
This change ensures files that use tabs (`\t`) for spacing are correctly scanned for significant changes. This was affecting Go SDKs in particular. Additionally, it updates the action to ignore changes to version and user-agent info in source files since these are explicitly insignificant changes.