### PR TITLE
fix: overlay implementation

### DIFF
--- a/internal/actions/generate.go
+++ b/internal/actions/generate.go
@@ -91,6 +91,13 @@ func Generate() error {
 						Path:        path,
 					}
 				}
+				if lang == "terraform" {
+					// Also trigger "go generate ./..." to regenerate docs
+					err = cli.TriggerGoGenerate()
+					if err != nil {
+						return err
+					}
+				}
 			}
 		}
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -53,7 +53,7 @@ func TriggerGoGenerate() error {
 	tidyCmd.Dir = filepath.Join(environment.GetWorkspace(), "repo", environment.GetWorkingDirectory())
 	output, err := tidyCmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("error running command: go mod tidy - %w\n", err, string(output))
+		return fmt.Errorf("error running command: go mod tidy - %w\n %s", err, string(output))
 	}
 	generateCmd := exec.Command("go", "generate", "./...")
 	generateCmd.Dir = filepath.Join(environment.GetWorkspace(), "repo", environment.GetWorkingDirectory())

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,7 +2,10 @@ package cli
 
 import (
 	"fmt"
+	"github.com/speakeasy-api/sdk-generation-action/internal/environment"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -43,6 +46,25 @@ func GetSupportedLanguages() ([]string, error) {
 	langs := r.FindStringSubmatch(strings.TrimSpace(out))[1]
 
 	return strings.Split(langs, ", "), nil
+}
+
+func TriggerGoGenerate() error {
+	tidyCmd := exec.Command("go", "mod", "tidy")
+	tidyCmd.Dir = filepath.Join(environment.GetWorkspace(), "repo", environment.GetWorkingDirectory())
+	output, err := tidyCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error running command: go mod tidy - %w\n", err, string(output))
+	}
+	generateCmd := exec.Command("go", "generate", "./...")
+	generateCmd.Dir = filepath.Join(environment.GetWorkspace(), "repo", environment.GetWorkingDirectory())
+	// connect generateCmd stdout to this stdout
+	generateCmd.Stdout = os.Stdout
+	err = generateCmd.Run()
+	if err != nil {
+		return fmt.Errorf("error running command: go generate ./... - %w\n", err)
+	}
+
+	return nil
 }
 
 func GetSpeakeasyVersion() (*version.Version, error) {

--- a/internal/document/document.go
+++ b/internal/document/document.go
@@ -128,18 +128,18 @@ func mergeFiles(files []string) (string, error) {
 }
 
 func applyOverlay(filePath string, overlayFiles []string) (string, error) {
-	outPath := filepath.Join(environment.GetWorkspace(), "openapi", "openapi_overlay")
+	for i, overlayFile := range overlayFiles {
+		outPath := filepath.Join(environment.GetWorkspace(), "openapi", fmt.Sprintf("openapi_overlay_%v", i))
 
-	if err := os.MkdirAll(filepath.Dir(outPath), os.ModePerm); err != nil {
-		return "", fmt.Errorf("failed to create openapi directory: %w", err)
-	}
+		if err := os.MkdirAll(filepath.Dir(outPath), os.ModePerm); err != nil {
+			return "", fmt.Errorf("failed to create openapi directory: %w", err)
+		}
 
-	outPathAbs, err := filepath.Abs(outPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to get absolute path for openapi overlay file: %w", err)
-	}
+		outPathAbs, err := filepath.Abs(outPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to get absolute path for openapi overlay file: %w", err)
+		}
 
-	for _, overlayFile := range overlayFiles {
 		if err := cli.ApplyOverlay(overlayFile, filePath, outPathAbs); err != nil {
 			return "", fmt.Errorf("failed to apply overlay: %w", err)
 		}


### PR DESCRIPTION
Modification of base directory seemed to effect the output. This moves the overlayed file to always be in the same base directory as other overlay files. 

This also removes assumptions on the current working directory by ensuring that the absPath of overlays/resolved openapi files is passed into the speakeasy binary as an argument