### PR TITLE
fix: discover version number changes (and ignore them) even when in an unusual location

### DIFF
--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -40,7 +40,7 @@ var (
 )
 
 type Git interface {
-	CheckDirDirty(dir string) (bool, error)
+	CheckDirDirty(dir string, ignoreMap map[string]string) (bool, error)
 }
 
 func Generate(g Git) (*GenerationInfo, map[string]string, error) {
@@ -145,7 +145,9 @@ func Generate(g Git) (*GenerationInfo, map[string]string, error) {
 
 			outputs[fmt.Sprintf("%s_directory", lang)] = dirForOutput
 
-			dirty, err := g.CheckDirDirty(dir)
+			dirty, err := g.CheckDirDirty(dir, map[string]string{
+				previousVersion: newVersion,
+			})
 			if err != nil {
 				return nil, outputs, err
 			}
@@ -321,7 +323,7 @@ func GenerateDocs(g Git) (*GenerationInfo, map[string]string, error) {
 
 		outputs["docs_directory"] = rootDir
 
-		dirty, err := g.CheckDirDirty(rootDir)
+		dirty, err := g.CheckDirDirty(rootDir, map[string]string{})
 		if err != nil {
 			return nil, outputs, err
 		}

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -110,10 +110,27 @@ index b26db52..fdc01f4 100755
 			},
 			want: true,
 		},
+		{
+			name: "ignores a version number change, even when compiled into an unusual line",
+			args: args{
+				// Important: Preserve tabs in the follow diff
+				diff: `diff --git a/gen.yaml b/gen.yaml
+index 322c845..585bc5b 100644
+--- a/useragent.go
++++ b/useragent.go
+- useragent := "%s/go 1.3.2 2.155.1 0.1.0-alpha openapi"
++ useragent := "%s/go 1.3.3 2.155.1 0.1.0-alpha openapi"
+`,
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsGitDiffSignificant(tt.args.diff)
+			got := IsGitDiffSignificant(tt.args.diff, map[string]string{
+				// example version number change
+				"1.3.2": "1.3.3",
+			})
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -80,7 +80,7 @@ func (g *Git) CloneRepo() error {
 	return nil
 }
 
-func (g *Git) CheckDirDirty(dir string) (bool, error) {
+func (g *Git) CheckDirDirty(dir string, ignoreChangePatterns map[string]string) (bool, error) {
 	if g.repo == nil {
 		return false, fmt.Errorf("repo not cloned")
 	}
@@ -146,7 +146,7 @@ func (g *Git) CheckDirDirty(dir string) (bool, error) {
 		return false, fmt.Errorf("error running git diff: %w", err)
 	}
 
-	return IsGitDiffSignificant(diffOutput), nil
+	return IsGitDiffSignificant(diffOutput, ignoreChangePatterns), nil
 }
 
 func (g *Git) FindExistingPR(branchName string, action environment.Action) (string, *github.PullRequest, error) {


### PR DESCRIPTION
Not as clever as a version number string canary; but didn't want to do multiple passes through generation.