### PR TITLE
fix: remove dotnet version from config definition

### DIFF
--- a/.github/action-inputs-config.json
+++ b/.github/action-inputs-config.json
@@ -49,9 +49,5 @@
   {
     "name": "publish_terraform",
     "language": "terraform"
-  },
-  {
-    "name": "dotnet_version",
-    "language": "csharp"
   }
 ]


### PR DESCRIPTION
Turns out we aren't handling this correctly yet. So just remove it for now so we can ship the other bit 