### PR TITLE
feat: put docs command under generate

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,13 +2,14 @@ package cli
 
 import (
 	"fmt"
-	"github.com/speakeasy-api/sdk-generation-action/internal/environment"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/speakeasy-api/sdk-generation-action/internal/environment"
 
 	"github.com/hashicorp/go-version"
 	"github.com/speakeasy-api/sdk-generation-action/internal/logging"
@@ -278,8 +279,8 @@ func Generate(docPath, lang, outputDir, installationURL string, published, outpu
 
 func GenerateDocs(docPath, langs, outputDir string) error {
 	args := []string{
-		"docs",
 		"generate",
+		"docs",
 		"-s",
 		docPath,
 		"-l",


### PR DESCRIPTION
To merge after this CLI is [released](https://github.com/speakeasy-api/speakeasy/pull/349)

Again technically this would be backwards incompatible if it was used frequently in the wild but given we are mostly setting up the docs action manually right now we can make this change now.