### PR TITLE
fix: run correct c# build command

### DIFF
--- a/.github/workflows/sdk-generation.yaml
+++ b/.github/workflows/sdk-generation.yaml
@@ -692,7 +692,14 @@ jobs:
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
 
-      - run: dotnet format && dotnet build
+      - name: Compile 5.X
+        if: ${{ startsWith(inputs.dotnet_version, '5') }}
+        run: dotnet build
+        working-directory: ${{ needs.generate.outputs.csharp_directory }}
+
+      - name: Compile 6.X
+        if: ${{ startsWith(inputs.dotnet_version, '6') }}
+        run: dotnet format && dotnet build
         working-directory: ${{ needs.generate.outputs.csharp_directory }}
 
       - uses: ravsamhq/notify-slack-action@v2


### PR DESCRIPTION
`dotnet format` is only supported in v 6+