### PR TITLE
feat: error message in github actions log proxy

### DIFF
--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -40,7 +40,7 @@ func LogActionResult() error {
 	logMessage := "Success in Github Action"
 	if !strings.Contains(strings.ToLower(os.Getenv("GH_ACTION_RESULT")), "success") {
 		logLevel = logProxyLevelError
-		logMessage = "Failure in Github Action"
+		logMessage = fmt.Sprintf("Failure in Github Action: %s", os.Getenv("GH_ACTION_RESULT"))
 	}
 
 	request := logProxyEntry{


### PR DESCRIPTION
This will be a start. We will at least get the full error message with our failure logs.

Not as ideal as us just getting native datadog logging from github actions, but we still have some stuff to figure out there.