### PR TITLE
feat: reset PR branches rather than appending

### DIFF
--- a/internal/actions/finalize-suggestion.go
+++ b/internal/actions/finalize-suggestion.go
@@ -31,7 +31,7 @@ func FinalizeSuggestion() error {
 		}
 	}()
 
-	branchName, err = g.FindBranch(branchName)
+	branchName, err = g.FindAndCheckoutBranch(branchName)
 	if err != nil {
 		return err
 	}

--- a/internal/actions/runWorkflow.go
+++ b/internal/actions/runWorkflow.go
@@ -151,7 +151,7 @@ func finalize(outputs map[string]string, branchName string, anythingRegenerated 
 		return nil
 	}
 
-	branchName, err := g.FindBranch(branchName)
+	branchName, err := g.FindAndCheckoutBranch(branchName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The goal of this change is to reset PR branches instead of adding to them, such that SDK PRs don't grow endlessly (and their versions along with it)