### PR TITLE
fix: ignore workflow.lock when checking dirtiness

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -112,9 +112,13 @@ func (g *Git) CheckDirDirty(dir string, ignoreChangePatterns map[string]string) 
 	fileChangesFound := false
 	newFiles := []string{}
 
+	filesToIgnore := []string{"gen.yaml", "gen.lock", "workflow.yaml", "workflow.lock"}
+
 	for f, s := range status {
-		if strings.Contains(f, "gen.yaml") || strings.Contains(f, "gen.lock") {
-			continue
+		for _, fileToIgnore := range filesToIgnore {
+			if strings.Contains(f, fileToIgnore) {
+				continue
+			}
 		}
 
 		if strings.HasPrefix(f, cleanedDir) {


### PR DESCRIPTION
https://linear.app/speakeasy/issue/SPE-3270/bug-with-creating-prs-due-to-recent-addition-of-workflowlock-will