### PR TITLE
feat: registry tags in action input

### DIFF
--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -131,7 +131,7 @@ jobs:
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: run-workflow
         name: Run Generation Workflow
-        uses: speakeasy-api/sdk-generation-action@v15.7.0
+        uses: speakeasy-api/sdk-generation-action@v15
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -131,7 +131,7 @@ jobs:
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: run-workflow
         name: Run Generation Workflow
-        uses: speakeasy-api/sdk-generation-action@v15
+        uses: speakeasy-api/sdk-generation-action@v15.7.0
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -36,6 +36,10 @@ on:
         description: "The working directory for running Speakeasy CLI commands in the action"
         required: false
         type: string
+      registry_tags:
+        description: "Multi-line or single-line string input of tags to apply to speakeasy registry builds"
+        required: false
+        type: string
     secrets:
       github_access_token:
         description: A GitHub access token with write access to the repo
@@ -127,7 +131,7 @@ jobs:
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: run-workflow
         name: Run Generation Workflow
-        uses: speakeasy-api/sdk-generation-action@v15
+        uses: speakeasy-api/sdk-generation-action@v15.7.0
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}
@@ -139,6 +143,7 @@ jobs:
           working_directory: ${{ inputs.working_directory }}
           openapi_doc_auth_token: ${{ secrets.openapi_doc_auth_token }}
           target: ${{ inputs.target }}
+          registry_tags: ${{ inputs.registry_tags }}
       - uses: ravsamhq/notify-slack-action@v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:

--- a/action.yml
+++ b/action.yml
@@ -143,7 +143,7 @@ outputs:
     description: "The location of the OpenAPI document used for generation"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15"
+  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.7.0"
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   target:
     description: "Generate a specific target by name"
     required: false
+  registry_tags:
+    description: "Multi-line or single-line string input of tags to apply to speakeasy registry builds"
+    required: false
   max_suggestions:
     description: "The maximum number of suggestions to apply when using the 'suggest' action step."
     default: "5"
@@ -140,7 +143,7 @@ outputs:
     description: "The location of the OpenAPI document used for generation"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15"
+  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.7.0"
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}
@@ -161,3 +164,4 @@ runs:
     - ${{ inputs.gpg_fingerprint }}
     - ${{ inputs.openapi_doc_auth_token }}
     - ${{ inputs.target }}
+    - ${{ inputs.registry_tags }}

--- a/action.yml
+++ b/action.yml
@@ -143,7 +143,7 @@ outputs:
     description: "The location of the OpenAPI document used for generation"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.7.0"
+  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15"
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -49,7 +49,7 @@ func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, r
 
 	tags := processRegistryTags()
 	for _, tag := range tags {
-		args = append(args, "--registry-tags", fmt.Sprintf("\"%s\"", tag))
+		args = append(args, "--registry-tags", tag)
 	}
 
 	if environment.ForceGeneration() {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -50,7 +50,7 @@ func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, r
 	tags := processRegistryTags()
 	if len(tags) > 0 {
 		tagString := strings.Join(tags, ",")
-		args = append(args, "--registry-tags", fmt.Sprintf("\"%s\"", tagString))
+		args = append(args, "--registry-tags", tagString)
 	}
 
 	if environment.ForceGeneration() {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -50,7 +50,8 @@ func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, r
 	tags := processRegistryTags()
 	if len(tags) > 0 {
 		tagString := strings.Join(tags, ",")
-		args = append(args, "--registry-tags", tagString)
+		fmt.Println("registry tags: ", tagString)
+		args = append(args, "--registry-tags", fmt.Sprintf("\"%s\"", tagString))
 	}
 
 	if environment.ForceGeneration() {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -50,7 +50,6 @@ func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, r
 	tags := processRegistryTags()
 	if len(tags) > 0 {
 		tagString := strings.Join(tags, ",")
-		fmt.Println("registry tags: ", tagString)
 		args = append(args, "--registry-tags", tagString)
 	}
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/speakeasy-api/sdk-generation-action/internal/environment"
 )
 
 type RunResults struct {
-	LintingReportURL string
+	LintingReportURL     string
 	ChangesReportURL     string
 	OpenAPIChangeSummary string
 }
@@ -44,6 +45,12 @@ func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, r
 
 	if repoURL != "" {
 		args = append(args, "-r", repoURL)
+	}
+
+	tags := processRegistryTags()
+	for _, tag := range tags {
+		// TODO: Just an example. This will be actual arguments to speakeasy run
+		fmt.Println(fmt.Sprintf("--bundle-tag: \"%s\"", tag))
 	}
 
 	if environment.ForceGeneration() {
@@ -105,4 +112,25 @@ func getChangesReportURL(out string) string {
 	}
 
 	return ""
+}
+
+func processRegistryTags() []string {
+	var tags []string
+	tagsInput := environment.RegistryTags()
+	if len(strings.Trim(tagsInput, " ")) == 0 {
+		return tags
+	}
+
+	var processedTags []string
+	if strings.Contains(tagsInput, "\n") {
+		processedTags = strings.Split(tagsInput, "\n")
+	} else {
+		processedTags = strings.Split(tagsInput, ",")
+	}
+
+	for _, tag := range processedTags {
+		tags = append(tags, strings.Trim(tag, " "))
+	}
+
+	return tags
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -129,7 +129,10 @@ func processRegistryTags() []string {
 	}
 
 	for _, tag := range processedTags {
-		tags = append(tags, strings.Trim(tag, " "))
+		tag = strings.Trim(tag, " ")
+		if len(tag) == 0 {
+			tags = append(tags, tag)
+		}
 	}
 
 	return tags

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -48,9 +48,9 @@ func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, r
 	}
 
 	tags := processRegistryTags()
-	for _, tag := range tags {
-		// TODO: Replace with actual speakeasy run argument
-		fmt.Println(fmt.Sprintf("--bundle-tag: \"%s\"", tag))
+	if len(tags) > 0 {
+		tagString := strings.Join(tags, ",")
+		args = append(args, "--registry-tags", fmt.Sprintf("\"%s\"", tagString))
 	}
 
 	if environment.ForceGeneration() {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -47,10 +47,8 @@ func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, r
 		args = append(args, "-r", repoURL)
 	}
 
-	tags := processRegistryTags()
-	for _, tag := range tags {
-		args = append(args, "--registry-tags", tag)
-	}
+	//tags := processRegistryTags()
+	args = append(args, "--registry-tags ryan")
 
 	if environment.ForceGeneration() {
 		fmt.Println("force input enabled - setting SPEAKEASY_FORCE_GENERATION=true")

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -48,10 +48,8 @@ func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, r
 	}
 
 	tags := processRegistryTags()
-	if len(tags) > 0 {
-		tagString := strings.Join(tags, ",")
-		fmt.Println("registry tags: ", tagString)
-		args = append(args, "--registry-tags", fmt.Sprintf("\"%s\"", tagString))
+	for _, tag := range tags {
+		args = append(args, "--registry-tags", fmt.Sprintf("\"%s\"", tag))
 	}
 
 	if environment.ForceGeneration() {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -49,7 +49,7 @@ func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, r
 
 	tags := processRegistryTags()
 	for _, tag := range tags {
-		// TODO: Just an example. This will be actual arguments to speakeasy run
+		// TODO: Replace with actual speakeasy run argument
 		fmt.Println(fmt.Sprintf("--bundle-tag: \"%s\"", tag))
 	}
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -130,7 +130,7 @@ func processRegistryTags() []string {
 
 	for _, tag := range processedTags {
 		tag = strings.Trim(tag, " ")
-		if len(tag) == 0 {
+		if len(tag) > 0 {
 			tags = append(tags, tag)
 		}
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -47,8 +47,12 @@ func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, r
 		args = append(args, "-r", repoURL)
 	}
 
-	//tags := processRegistryTags()
-	args = append(args, "--registry-tags ryan")
+	tags := processRegistryTags()
+	if len(tags) > 0 {
+		tagString := strings.Join(tags, ",")
+		fmt.Println("registry tags: ", tagString)
+		args = append(args, "--registry-tags", tagString)
+	}
 
 	if environment.ForceGeneration() {
 		fmt.Println("force input enabled - setting SPEAKEASY_FORCE_GENERATION=true")
@@ -114,7 +118,7 @@ func getChangesReportURL(out string) string {
 func processRegistryTags() []string {
 	var tags []string
 	tagsInput := environment.RegistryTags()
-	if len(strings.Trim(tagsInput, " ")) == 0 {
+	if len(strings.Replace(tagsInput, " ", "", -1)) == 0 {
 		return tags
 	}
 
@@ -126,7 +130,7 @@ func processRegistryTags() []string {
 	}
 
 	for _, tag := range processedTags {
-		tag = strings.Trim(tag, " ")
+		tag = strings.Replace(tag, " ", "", -1)
 		if len(tag) > 0 {
 			tags = append(tags, tag)
 		}

--- a/internal/cli/speakeasy.go
+++ b/internal/cli/speakeasy.go
@@ -79,8 +79,6 @@ func runSpeakeasyCommand(args ...string) (string, error) {
 
 	cmdPath := filepath.Join(baseDir, "bin", "speakeasy")
 
-	fmt.Println("args", args)
-
 	cmd := exec.Command(cmdPath, args...)
 	cmd.Dir = filepath.Join(environment.GetWorkspace(), "repo", environment.GetWorkingDirectory())
 	cmd.Env = os.Environ()

--- a/internal/cli/speakeasy.go
+++ b/internal/cli/speakeasy.go
@@ -79,6 +79,8 @@ func runSpeakeasyCommand(args ...string) (string, error) {
 
 	cmdPath := filepath.Join(baseDir, "bin", "speakeasy")
 
+	fmt.Println("args", args)
+
 	cmd := exec.Command(cmdPath, args...)
 	cmd.Dir = filepath.Join(environment.GetWorkspace(), "repo", environment.GetWorkingDirectory())
 	cmd.Env = os.Environ()

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -56,6 +56,10 @@ func ForceGeneration() bool {
 	return os.Getenv("INPUT_FORCE") == "true"
 }
 
+func RegistryTags() string {
+	return os.Getenv("INPUT_REGISTRY_TAGS")
+}
+
 func SpecifiedTarget() string {
 	return os.Getenv("INPUT_TARGET")
 }


### PR DESCRIPTION
Support passing in tags as an input to sdk-generation-action as discussed in this [RFC](https://www.notion.so/speakeasyapi/RFC-Thoughts-on-Tagging-One-Pager-2f0dcfd18f0d47d98e9b7c2e2b1f439f?pm=c)

Here's an example of a few different tag input formats that we can simultaneously support. These are all tested and they work.

- [Most readable](https://github.com/ryan-timothy-albert/sample-spec-workflow/blob/47d0c908f3197603b4468c88877ae7bffc2e642a/.github/workflows/sdk_generation.yaml)
- [Single Line](https://github.com/ryan-timothy-albert/sample-spec-workflow/blob/94d5af8fa65b47b1896e2bf9963f89f15494b36c/.github/workflows/sdk_generation.yaml)
- [Advanced Usecases](https://github.com/ryan-timothy-albert/sample-spec-workflow/blob/a649eb949b4d6df58e313c0e43a5b21df9142b04/.github/workflows/sdk_generation.yaml) - this would encompass things like conditional tagging based on github variables. Unfortunately, github actions does not support the single line if statement format, that would be super ideal.


Overall, this approach provides a good amount of flexibility to the github action user. We will of course have support documentation on our recommended ways to setup different types of tagging.

Notes:
- Right now this is just printing. I'm currently working on implementing tagging as an argument `speakeasy run` as we speak.
- Let's have a bit of debate on how we feel about naming of `registry-tags` vs `build-tags`. I kind of like registry-tags in the action because its more directly aligned with our concept of speakeasy registry as a product. Certainly would like to hear other opinions.