### PR TITLE
feat: add publishing CLI events support python

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -137,7 +137,7 @@ jobs:
           python setup.py sdist bdist_wheel
           twine upload dist/*
       - id: publish-event
-        uses: speakeasy-api/sdk-generation-action@v15.9.0
+        uses: speakeasy-api/sdk-generation-action@v15
         if: always()
         with:
           github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -137,7 +137,7 @@ jobs:
           python setup.py sdist bdist_wheel
           twine upload dist/*
       - id: publish-event
-        uses: speakeasy-api/sdk-generation-action@v15
+        uses: speakeasy-api/sdk-generation-action@v15.9.0
         if: always()
         with:
           github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -136,6 +136,18 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
           twine upload dist/*
+      - id: publish-event
+        uses: speakeasy-api/sdk-generation-action@v15
+        if: always()
+        with:
+          github_access_token: ${{ secrets.github_access_token }}
+          action: publish-event
+          speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
+          registry_name: "pypi"
+        env:
+          GH_ACTION_RESULT: ${{ job.status }}
+          GH_ACTION_VERSION: "v15"
       - uses: ravsamhq/notify-slack-action@v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:

--- a/action.yml
+++ b/action.yml
@@ -145,7 +145,7 @@ outputs:
     description: "The name of the publishing registry"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15"
+  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.9.0"
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}

--- a/action.yml
+++ b/action.yml
@@ -145,7 +145,7 @@ outputs:
     description: "The name of the publishing registry"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.9.0"
+  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15"
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}

--- a/action.yml
+++ b/action.yml
@@ -141,6 +141,8 @@ outputs:
     description: "The version of the previous generation"
   openapi_doc:
     description: "The location of the OpenAPI document used for generation"
+  registry_name:
+    description: "The name of the publishing registry"
 runs:
   using: "docker"
   image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15"
@@ -165,3 +167,5 @@ runs:
     - ${{ inputs.openapi_doc_auth_token }}
     - ${{ inputs.target }}
     - ${{ inputs.registry_tags }}
+    - ${{ inputs.registry_name }}
+

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/speakeasy-api/sdk-generation-action
 go 1.21.0
 
 require (
+	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.11.0
 	github.com/google/go-github/v54 v54.0.0
 	github.com/google/uuid v1.6.0
@@ -10,7 +11,7 @@ require (
 	github.com/pb33f/libopenapi v0.14.0
 	github.com/speakeasy-api/git-diff-parser v0.0.3
 	github.com/speakeasy-api/sdk-gen-config v1.7.4
-	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.4.1
+	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.7.1
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20231127185646-65229373498e
 	golang.org/x/oauth2 v0.11.0
@@ -33,7 +34,6 @@ require (
 	github.com/ericlagergren/decimal v0.0.0-20240305081647-93d586550569 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/speakeasy-api/git-diff-parser v0.0.3 h1:LL12d+HMtSyj6O/hQqIn/lgDPYI6c
 github.com/speakeasy-api/git-diff-parser v0.0.3/go.mod h1:P46HmmVVmwA9P8h2wa0fDpmRM8/grbVQ+uKhWDtpkIY=
 github.com/speakeasy-api/sdk-gen-config v1.7.4 h1:hk3GaKiL6zxx3SulnxdunvU2V7bUSQ4YviXtIiUmWuo=
 github.com/speakeasy-api/sdk-gen-config v1.7.4/go.mod h1:4R+8FTyM6UdLHltOVAigIoR5D2UfPsGMmEFzPOP1yCs=
-github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.4.1 h1:7bnCFOsWDhce7m0Btgsxjq30ZGlluXDm21hI6qj2BPc=
-github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.4.1/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
+github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.7.1 h1:8cfPRFXn9a7IMBAQFhQ0N4rKCHMqWclVBGTEmXKXrZ4=
+github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.7.1/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/internal/actions/publishEvent.go
+++ b/internal/actions/publishEvent.go
@@ -1,0 +1,99 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	config "github.com/speakeasy-api/sdk-gen-config"
+	"github.com/speakeasy-api/sdk-generation-action/internal/telemetry"
+	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
+)
+
+func PublishEvent() error {
+	return telemetry.Track(context.Background(), shared.InteractionTypePublish, func(ctx context.Context, event *shared.CliEvent) error {
+		registryName := os.Getenv("INPUT_REGISTRY_NAME")
+		if registryName != "" {
+			event.PublishPackageRegistryName = &registryName
+		}
+
+		workingDir, err := os.Getwd() // in publishing working dir is the SDK output directory
+		if err != nil {
+			return err
+		}
+
+		loadedCfg, err := config.Load(workingDir)
+		if err != nil {
+			return err
+		}
+
+		if loadedCfg.LockFile == nil {
+			return fmt.Errorf("empty lock file for python language target in directory %s", workingDir)
+		}
+
+		version := processLockFile(*loadedCfg.LockFile, event)
+
+		var processingErr error
+		switch os.Getenv("INPUT_REGISTRY_NAME") {
+		case "pypy":
+			processingErr = processPyPI(loadedCfg, event, workingDir, version)
+		}
+
+		if processingErr != nil {
+			return processingErr
+		}
+
+		if !strings.Contains(strings.ToLower(os.Getenv("GH_ACTION_RESULT")), "success") {
+			return fmt.Errorf("failure in publishing: %s", os.Getenv("GH_ACTION_RESULT"))
+		}
+
+		return nil
+	})
+}
+
+func processPyPI(cfg *config.Config, event *shared.CliEvent, workingDir string, version string) error {
+	if cfg.Config == nil {
+		return fmt.Errorf("empty config for python language target in directory %s", workingDir)
+	}
+
+	langCfg, ok := cfg.Config.Languages["python"]
+	if !ok {
+		return fmt.Errorf("no python config in directory %s", workingDir)
+	}
+
+	var packageName string
+	if name, ok := langCfg.Cfg["packageName"]; ok {
+		if strName, ok := name.(string); ok {
+			packageName = strName
+		}
+	}
+
+	if packageName != "" {
+		event.PublishPackageName = &packageName
+	}
+
+	if packageName != "" && version != "" {
+		publishURL := fmt.Sprintf("https://pypi.org/project/%s/%s/", packageName, version)
+		event.PublishPackageURL = &publishURL
+	}
+
+	return nil
+
+}
+
+func processLockFile(lockFile config.LockFile, event *shared.CliEvent) string {
+	if lockFile.ID != "" {
+		event.GenerateGenLockID = &lockFile.ID
+	}
+
+	if lockFile.Management.ReleaseVersion != "" {
+		event.PublishPackageVersion = &lockFile.Management.ReleaseVersion
+	}
+
+	if lockFile.Management.SpeakeasyVersion != "" {
+		event.SpeakeasyVersion = lockFile.Management.SpeakeasyVersion
+	}
+
+	return lockFile.Management.SpeakeasyVersion
+}

--- a/internal/actions/publishEvent.go
+++ b/internal/actions/publishEvent.go
@@ -16,6 +16,8 @@ func PublishEvent() error {
 		registryName := os.Getenv("INPUT_REGISTRY_NAME")
 		if registryName != "" {
 			event.PublishPackageRegistryName = &registryName
+			fmt.Println("REGISTRY NAME")
+			fmt.Println(registryName)
 		}
 
 		workingDir, err := os.Getwd() // in publishing working dir is the SDK output directory
@@ -71,11 +73,15 @@ func processPyPI(cfg *config.Config, event *shared.CliEvent, workingDir string, 
 
 	if packageName != "" {
 		event.PublishPackageName = &packageName
+		fmt.Println("PACKAGE NAME")
+		fmt.Println(packageName)
 	}
 
 	if packageName != "" && version != "" {
 		publishURL := fmt.Sprintf("https://pypi.org/project/%s/%s/", packageName, version)
 		event.PublishPackageURL = &publishURL
+		fmt.Println("PUBLISH URL")
+		fmt.Println(publishURL)
 	}
 
 	return nil
@@ -85,10 +91,14 @@ func processPyPI(cfg *config.Config, event *shared.CliEvent, workingDir string, 
 func processLockFile(lockFile config.LockFile, event *shared.CliEvent) string {
 	if lockFile.ID != "" {
 		event.GenerateGenLockID = &lockFile.ID
+		fmt.Println("Lock File ID")
+		fmt.Println(lockFile.ID)
 	}
 
 	if lockFile.Management.ReleaseVersion != "" {
 		event.PublishPackageVersion = &lockFile.Management.ReleaseVersion
+		fmt.Println("RELEASE VERSION")
+		fmt.Println(lockFile.Management.ReleaseVersion)
 	}
 
 	if lockFile.Management.SpeakeasyVersion != "" {

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -25,6 +25,7 @@ const (
 	ActionFinalizeSuggestion Action = "finalize-suggestion"
 	ActionRelease            Action = "release"
 	ActionLog                Action = "log-result"
+	ActionPublishEvent       Action = "publish-event"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/speakeasy-api/sdk-generation-action/internal/telemetry"
-	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
 	"os"
 	"strings"
+
+	"github.com/speakeasy-api/sdk-generation-action/internal/telemetry"
+	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
 
 	"github.com/speakeasy-api/sdk-generation-action/internal/actions"
 	"github.com/speakeasy-api/sdk-generation-action/internal/environment"
@@ -38,21 +39,22 @@ func main() {
 
 	err = telemetry.Track(context.Background(), shared.InteractionTypeCiExec, func(ctx context.Context, event *shared.CliEvent) error {
 		switch environment.GetAction() {
-	case environment.ActionSuggest:
-		return actions.Suggest()
-	case environment.ActionRunWorkflow:
-		return actions.RunWorkflow()
-	case environment.ActionFinalizeSuggestion:
-		return actions.FinalizeSuggestion()
-	case environment.ActionRelease:
-		return actions.Release()
-	case environment.ActionLog:
-		return actions.LogActionResult()
-	default:
-		return fmt.Errorf("unknown action: %s", environment.GetAction())
+		case environment.ActionSuggest:
+			return actions.Suggest()
+		case environment.ActionRunWorkflow:
+			return actions.RunWorkflow()
+		case environment.ActionFinalizeSuggestion:
+			return actions.FinalizeSuggestion()
+		case environment.ActionRelease:
+			return actions.Release()
+		case environment.ActionLog:
+			return actions.LogActionResult()
+		case environment.ActionPublishEvent:
+			return actions.PublishEvent()
+		default:
+			return fmt.Errorf("unknown action: %s", environment.GetAction())
 		}
 	})
-
 
 	if err != nil {
 		fmt.Printf("::error title=failed::%v\n", err)


### PR DESCRIPTION
Start sending publishing CLI events for dashboard visualization even though publishing itself doesn't go through the CLI.

I implemented this for PYPI first. Once we are good with approach will extend it to more package managers. We can also add more event metadata overtime as we want more. We should always have access to gen lock and gen files.