### PR TITLE
feat: add support for .NET8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,16 @@ RUN apk add --update --no-cache openjdk11 gradle
 ### Install Ruby
 RUN apk add --update --no-cache build-base ruby ruby-bundler ruby-dev
 
-### Install .NET 6.0
+### Install .NET6.0
 ENV DOTNET_ROOT=/usr/lib/dotnet
 RUN apk add --update --no-cache dotnet6-sdk
 
-# Install .NET 5.0
+### Install .NET5.0
 RUN apk add --update --no-cache curl bash openssl1.1-compat
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -Channel 5.0 -InstallDir ${DOTNET_ROOT}
+
+### Install .NET8.0
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -Channel 8.0 -InstallDir ${DOTNET_ROOT}
 RUN dotnet --list-sdks
 
 ### Install PHP and Composer


### PR DESCRIPTION
SPE-3381: install .NET8.0 alongside .NET5.0 and .NET6.0

Tested inside local container:
```
$ which dotnet
/usr/bin/dotnet

$ dotnet --version
8.0.300

$ dotnet --list-sdks
5.0.408 [/usr/lib/dotnet/sdk]
6.0.125 [/usr/lib/dotnet/sdk]
8.0.300 [/usr/lib/dotnet/sdk] 
```
