### PR TITLE
feat: populate code samples in the registry

### DIFF
--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -40,6 +40,10 @@ on:
         description: "Multi-line or single-line string input of tags to apply to speakeasy registry builds"
         required: false
         type: string
+      push_code_samples_only:
+        description: "This will generate code samples, tag them with the `main` branch name, and push them to the registry. It will not create a pull request or commit any code. This is useful for pushing up some code samples to the registry the first time when there are no code samples in the registry."
+        required: false
+        type: boolean
     secrets:
       github_access_token:
         description: A GitHub access token with write access to the repo
@@ -143,6 +147,7 @@ jobs:
           openapi_doc_auth_token: ${{ secrets.openapi_doc_auth_token }}
           target: ${{ inputs.target }}
           registry_tags: ${{ inputs.registry_tags }}
+          push_code_samples_only: ${{ inputs.push_code_samples }}
       - uses: ravsamhq/notify-slack-action@v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ test-direct-mode-multi-sdk:
 test-pr-mode:
 	./testing/test.sh ./testing/pr-mode.env
 
+test-push-code-samples-only:
+	./testing/test.sh ./testing/push-code-samples-only.env
+
 test-release-mode:
 	./testing/test.sh ./testing/release-mode.env
 

--- a/action.yml
+++ b/action.yml
@@ -72,6 +72,9 @@ inputs:
   gpg_fingerprint:
     description: "The GPG fingerprint to sign the release with"
     required: false
+  push_code_samples_only:
+    description: "This will generate code samples, tag them with the `main` branch name, and push them to the registry. It will not create a pull request or commit any code. This is useful for pushing up some code samples to the registry the first time when there are no code samples in the registry."
+    required: false
 outputs:
   publish_python:
     description: "Whether the Python SDK will be published to PyPi"

--- a/internal/actions/runWorkflow.go
+++ b/internal/actions/runWorkflow.go
@@ -52,9 +52,12 @@ func RunWorkflow() error {
 		}
 	}
 
-	branchName, err = g.FindOrCreateBranch(branchName, environment.ActionRunWorkflow)
-	if err != nil {
-		return err
+	// We want to stay on main if we're pushing code samples because we want to tag the code samples with `main`
+	if !environment.PushCodeSamplesOnly() {
+		branchName, err = g.FindOrCreateBranch(branchName, environment.ActionRunWorkflow)
+		if err != nil {
+			return err
+		}
 	}
 
 	success := false
@@ -117,6 +120,11 @@ func RunWorkflow() error {
 					}
 				}
 			}
+		}
+
+		if environment.PushCodeSamplesOnly() {
+			// If we're just pushing code samples we don't want to raise a PR
+			return nil
 		}
 
 		releasesDir, err := getReleasesDir()

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -57,6 +57,10 @@ func ForceGeneration() bool {
 	return os.Getenv("INPUT_FORCE") == "true"
 }
 
+func PushCodeSamplesOnly() bool {
+	return os.Getenv("INPUT_PUSH_CODE_SAMPLES_ONLY") == "true"
+}
+
 func RegistryTags() string {
 	return os.Getenv("INPUT_REGISTRY_TAGS")
 }

--- a/testing/push-code-samples-only.env
+++ b/testing/push-code-samples-only.env
@@ -1,0 +1,7 @@
+INPUT_MODE="pr"
+INPUT_ACTION="generate"
+INPUT_LANGUAGES="- go"
+GITHUB_REPOSITORY="speakeasy-api/sdk-generation-action-test-repo"
+INPUT_FORCE=true
+INPUT_PUSH_CODE_SAMPLES_ONLY=true
+RUN_FINALIZE=true


### PR DESCRIPTION
This will generate code samples, tag them with the `main` branch name, and push them to the registry. It will not create a pull request or commit any code. This is useful for pushing up some code samples to the registry the first time when there are no code samples in the registry. This is for the Mintlify Integration.