### PR TITLE
fix: require gh_access_token in tagging action

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -16,6 +16,9 @@ on:
         required: false
         type: string
     secrets:
+      github_access_token:
+        description: A GitHub access token with read access to the repo
+        required: true
       speakeasy_api_key:
         description: The API key to use to authenticate the Speakeasy CLI
         required: true


### PR DESCRIPTION
Update to tagging action