### PR TITLE
feat: allow non root working dir in run

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: release
-        uses: speakeasy-api/sdk-generation-action@v15.24.0
+        uses: speakeasy-api/sdk-generation-action@v15
         with:
           github_access_token: ${{ secrets.github_access_token }}
           action: "release"

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -7,6 +7,10 @@ on:
         required: false
         description: "Internal use only"
         type: string
+      working_directory:
+        description: "The working directory for running Speakeasy CLI commands in the action"
+        required: false
+        type: string
       dotnet_version:
         description: "The version of dotnet to use when compiling the C# SDK"
         required: false
@@ -93,11 +97,12 @@ jobs:
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: release
-        uses: speakeasy-api/sdk-generation-action@v15
+        uses: speakeasy-api/sdk-generation-action@v15.24.0
         with:
           github_access_token: ${{ secrets.github_access_token }}
           action: "release"
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
       - uses: ravsamhq/notify-slack-action@v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
@@ -159,6 +164,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: publish-event
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
           target_directory: ${{ needs.release.outputs.python_directory }}
           registry_name: "pypi"
@@ -206,6 +212,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: publish-event
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
           target_directory: ${{ needs.release.outputs.typescript_directory }}
           registry_name: "npm"
@@ -268,6 +275,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: publish-event
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
           target_directory: ${{ needs.release.outputs.java_directory }}
           registry_name: "sonatype"
@@ -310,6 +318,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: publish-event
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
           target_directory: ${{ needs.release.outputs.php_directory }}
           registry_name: "packagist"
@@ -352,6 +361,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: publish-event
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
           target_directory: ${{ needs.release.outputs.csharp_directory }}
           registry_name: "nuget"
@@ -392,6 +402,7 @@ jobs:
         with:
           github_access_token: ${{ secrets.github_access_token }}
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           gpg_fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}
           action: "release"
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
@@ -404,6 +415,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: publish-event
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
           target_directory: ${{ needs.release.outputs.publish_terraform }}
           registry_name: "terraform"
@@ -456,6 +468,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: publish-event
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
           target_directory: ${{ needs.release.outputs.ruby_directory }}
           registry_name: "gems"

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -11,6 +11,10 @@ on:
         description: "The targets to tag code samples for (comma or newline separated)"
         required: false
         type: string
+      working_directory:
+        description: "The working directory for running Speakeasy CLI commands in the action"
+        required: false
+        type: string
       registry_tags:
         description: "Multi-line or single-line string input of tags to apply to speakeasy registry builds"
         required: false
@@ -36,6 +40,7 @@ jobs:
           action: "tag"
           sources: ${{ inputs.sources }}
           code_samples: ${{ inputs.code_samples }}
+          working_directory: ${{ inputs.working_directory }}
           registry_tags: ${{ inputs.registry_tags }}
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
           github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -172,6 +172,7 @@ jobs:
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}
+          working_directory: ${{ inputs.working_directory }}
           action: log-result
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
@@ -236,6 +237,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: publish-event
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
           target_directory: ${{ needs.run-workflow.outputs.python_directory }}
           registry_name: "pypi"
@@ -261,6 +263,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: log-result
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
@@ -304,6 +307,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: publish-event
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
           target_directory: ${{ needs.run-workflow.outputs.typescript_directory }}
           registry_name: "npm"
@@ -329,6 +333,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: log-result
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
@@ -388,6 +393,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: publish-event
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
           target_directory: ${{ needs.run-workflow.outputs.java_directory }}
           registry_name: "sonatype"
@@ -413,6 +419,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: log-result
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
@@ -461,6 +468,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: publish-event
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
           target_directory: ${{ needs.run-workflow.outputs.ruby_directory }}
           registry_name: "gems"
@@ -486,6 +494,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: log-result
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
@@ -524,6 +533,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: publish-event
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
           target_directory: ${{ needs.run-workflow.outputs.csharp_directory }}
           registry_name: "nuget"
@@ -549,6 +559,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: log-result
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
@@ -585,6 +596,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: publish-event
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
           target_directory: ${{ needs.run-workflow.outputs.php_directory }}
           registry_name: "packagist"
@@ -610,6 +622,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           action: log-result
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
+          working_directory: ${{ inputs.working_directory }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -139,7 +139,7 @@ jobs:
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: run-workflow
         name: Run Generation Workflow
-        uses: speakeasy-api/sdk-generation-action@v15.24.0
+        uses: speakeasy-api/sdk-generation-action@v15
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -139,7 +139,7 @@ jobs:
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: run-workflow
         name: Run Generation Workflow
-        uses: speakeasy-api/sdk-generation-action@v15
+        uses: speakeasy-api/sdk-generation-action@v15.23.0
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -139,7 +139,7 @@ jobs:
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: run-workflow
         name: Run Generation Workflow
-        uses: speakeasy-api/sdk-generation-action@v15.23.0
+        uses: speakeasy-api/sdk-generation-action@v15.24.0
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}

--- a/action.yml
+++ b/action.yml
@@ -162,7 +162,7 @@ outputs:
     description: "The directory the SDK target was generated to"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.24.0"
+  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15"
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}

--- a/action.yml
+++ b/action.yml
@@ -162,7 +162,7 @@ outputs:
     description: "The directory the SDK target was generated to"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15"
+  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.24.0"
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}

--- a/internal/actions/utils.go
+++ b/internal/actions/utils.go
@@ -1,12 +1,17 @@
 package actions
 
 import (
+	"path/filepath"
+
 	"github.com/speakeasy-api/sdk-generation-action/internal/configuration"
 	"github.com/speakeasy-api/sdk-generation-action/internal/environment"
 )
 
 func getReleasesDir() (string, error) {
 	releasesDir := "."
+	if environment.GetWorkingDirectory() != "" {
+		releasesDir = environment.GetWorkingDirectory()
+	}
 	// Find releases file
 	wf, err := configuration.GetWorkflowAndValidateLanguages(false)
 	if err != nil {
@@ -16,14 +21,24 @@ func getReleasesDir() (string, error) {
 	// Checking for multiple targets ensures backward compatibility with the code below
 	if len(wf.Targets) > 1 && environment.SpecifiedTarget() != "" {
 		if target, ok := wf.Targets[environment.SpecifiedTarget()]; ok && target.Output != nil {
-			return *target.Output, nil
+			if releasesDir != "." {
+				releasesDir = filepath.Join(releasesDir, *target.Output)
+			} else {
+				releasesDir = *target.Output
+			}
+
+			return releasesDir, nil
 		}
 	}
 
 	for _, target := range wf.Targets {
 		// If we are only generating one language and its not in the root directory we assume this is a multi-sdk repo
 		if len(wf.Targets) == 1 && target.Output != nil && *target.Output != "." {
-			releasesDir = *target.Output
+			if releasesDir != "." {
+				releasesDir = filepath.Join(releasesDir, *target.Output)
+			} else {
+				releasesDir = *target.Output
+			}
 		}
 	}
 

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -33,7 +33,7 @@ func GetWorkflowAndValidateLanguages(checkLangSupported bool) (*workflow.Workflo
 func getWorkflow() (*workflow.Workflow, error) {
 	workspace := environment.GetWorkspace()
 
-	localPath := filepath.Join(workspace, filepath.Join("repo", environment.GetWorkingDirectory()))
+	localPath := filepath.Join(workspace, "repo", environment.GetWorkingDirectory())
 
 	wf, _, err := workflow.Load(localPath)
 	if err != nil {

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -31,9 +31,9 @@ func GetWorkflowAndValidateLanguages(checkLangSupported bool) (*workflow.Workflo
 }
 
 func getWorkflow() (*workflow.Workflow, error) {
-	workspace := filepath.Join(environment.GetWorkspace(), environment.GetWorkingDirectory())
+	workspace := environment.GetWorkspace()
 
-	localPath := filepath.Join(workspace, "repo")
+	localPath := filepath.Join(workspace, filepath.Join("repo", environment.GetWorkingDirectory()))
 
 	wf, _, err := workflow.Load(localPath)
 	if err != nil {

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -31,10 +31,7 @@ func GetWorkflowAndValidateLanguages(checkLangSupported bool) (*workflow.Workflo
 }
 
 func getWorkflow() (*workflow.Workflow, error) {
-	workspace := environment.GetWorkspace()
-	if environment.GetWorkingDirectory() != "" {
-		workspace = filepath.Join(workspace, environment.GetWorkingDirectory())
-	}
+	workspace := filepath.Join(environment.GetWorkspace(), environment.GetWorkingDirectory())
 
 	localPath := filepath.Join(workspace, "repo")
 

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -32,6 +32,9 @@ func GetWorkflowAndValidateLanguages(checkLangSupported bool) (*workflow.Workflo
 
 func getWorkflow() (*workflow.Workflow, error) {
 	workspace := environment.GetWorkspace()
+	if environment.GetWorkingDirectory() != "" {
+		workspace = filepath.Join(workspace, environment.GetWorkingDirectory())
+	}
 
 	localPath := filepath.Join(workspace, "repo")
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/speakeasy-api/versioning-reports/versioning"
 	"net/url"
 	"os"
 	"os/exec"
@@ -16,6 +15,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/speakeasy-api/versioning-reports/versioning"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -249,7 +250,7 @@ func (g *Git) Reset(args ...string) error {
 	logging.Info("Running git  %s", strings.Join(args, " "))
 
 	cmd := exec.Command("git", args...)
-	cmd.Dir = filepath.Join(environment.GetWorkspace(), "repo", environment.GetWorkingDirectory())
+	cmd.Dir = filepath.Join(environment.GetWorkspace(), "repo")
 	cmd.Env = os.Environ()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -401,7 +402,7 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 func (g *Git) Add(arg string) error {
 	// We execute this manually because go-git doesn't properly support gitignore
 	cmd := exec.Command("git", "add", arg)
-	cmd.Dir = filepath.Join(environment.GetWorkspace(), "repo", environment.GetWorkingDirectory())
+	cmd.Dir = filepath.Join(environment.GetWorkspace(), "repo")
 	cmd.Env = os.Environ()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -759,7 +760,6 @@ func PRMetadata(m *versioning.MergedVersionReport, labelTypes map[string]github.
 	return strings.Join(builder, " "), labels
 }
 
-
 func (g *Git) CreateSuggestionPR(branchName, output string) (*int, string, error) {
 	body := fmt.Sprintf(`Generated OpenAPI Suggestions by Speakeasy CLI. 
     Outputs changes to *%s*.`, output)
@@ -1023,7 +1023,7 @@ func (g *Git) UpsertLabelTypes(ctx context.Context) map[string]github.Label {
 	desiredLabels := map[string]github.Label{}
 	addGitHubLabel := func(name, description string) {
 		desiredLabels[name] = github.Label{
-			Name: &name,
+			Name:        &name,
 			Description: &description,
 		}
 	}
@@ -1040,7 +1040,6 @@ func (g *Git) UpsertLabelTypes(ctx context.Context) map[string]github.Label {
 	for _, label := range allLabels {
 		actualLabels[*label.Name] = *label
 	}
-
 
 	for _, label := range desiredLabels {
 		foundLabel, ok := actualLabels[*label.Name]

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -250,7 +250,7 @@ func (g *Git) Reset(args ...string) error {
 	logging.Info("Running git  %s", strings.Join(args, " "))
 
 	cmd := exec.Command("git", args...)
-	cmd.Dir = filepath.Join(environment.GetWorkspace(), "repo")
+	cmd.Dir = filepath.Join(environment.GetWorkspace(), "repo", environment.GetWorkingDirectory())
 	cmd.Env = os.Environ()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -402,7 +402,7 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 func (g *Git) Add(arg string) error {
 	// We execute this manually because go-git doesn't properly support gitignore
 	cmd := exec.Command("git", "add", arg)
-	cmd.Dir = filepath.Join(environment.GetWorkspace(), "repo")
+	cmd.Dir = filepath.Join(environment.GetWorkspace(), "repo", environment.GetWorkingDirectory())
 	cmd.Env = os.Environ()
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -42,10 +42,7 @@ type Git interface {
 }
 
 func Run(g Git, pr *github.PullRequest, wf *workflow.Workflow) (*RunResult, map[string]string, error) {
-	workspace := environment.GetWorkspace()
-	if environment.GetWorkingDirectory() != "" {
-		workspace = filepath.Join(workspace, environment.GetWorkingDirectory())
-	}
+	workspace := filepath.Join(environment.GetWorkspace(), environment.GetWorkingDirectory())
 	outputs := map[string]string{}
 
 	speakeasyVersion, err := cli.GetSpeakeasyVersion()

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -42,7 +42,7 @@ type Git interface {
 }
 
 func Run(g Git, pr *github.PullRequest, wf *workflow.Workflow) (*RunResult, map[string]string, error) {
-	workspace := filepath.Join(environment.GetWorkspace(), environment.GetWorkingDirectory())
+	workspace := environment.GetWorkspace()
 	outputs := map[string]string{}
 
 	speakeasyVersion, err := cli.GetSpeakeasyVersion()
@@ -71,6 +71,7 @@ func Run(g Git, pr *github.PullRequest, wf *workflow.Workflow) (*RunResult, map[
 			dir = *target.Output
 		}
 
+		dir = filepath.Join(environment.GetWorkspace(), dir)
 		return dir, path.Join(workspace, "repo", dir)
 	}
 

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -43,6 +43,9 @@ type Git interface {
 
 func Run(g Git, pr *github.PullRequest, wf *workflow.Workflow) (*RunResult, map[string]string, error) {
 	workspace := environment.GetWorkspace()
+	if environment.GetWorkingDirectory() != "" {
+		workspace = filepath.Join(workspace, environment.GetWorkingDirectory())
+	}
 	outputs := map[string]string{}
 
 	speakeasyVersion, err := cli.GetSpeakeasyVersion()

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -71,7 +71,7 @@ func Run(g Git, pr *github.PullRequest, wf *workflow.Workflow) (*RunResult, map[
 			dir = *target.Output
 		}
 
-		dir = filepath.Join(environment.GetWorkspace(), dir)
+		dir = filepath.Join(environment.GetWorkingDirectory(), dir)
 		return dir, path.Join(workspace, "repo", dir)
 	}
 


### PR DESCRIPTION
We currently do not support placing your .speakeasy folder not in the root directory of a github repo. We need to support this less common usecase for some customers coming in.

To do this we ensure that the usage of the existing `working_directory` input. 

We actually don't use github actions run.working-directly because
1. This can't be used from uses which invokes our docker image
2. We actually don't want to change the entire directory away from root. Just the context of using speakeasy run