### PR TITLE
fix: C# Publishing when running in `direct` mode

### DIFF
--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -48,6 +48,11 @@ on:
         description: "Version to manually set for SDK generation"
         required: false
         type: string
+      dotnet_version:
+        description: "The version of dotnet to use when compiling the C# SDK"
+        required: false
+        type: string
+        default: "5.x"
     secrets:
       github_access_token:
         description: A GitHub access token with write access to the repo


### PR DESCRIPTION
This change populates a missing input to correctly setup dotnet for C# publishing in direct mode