### PR TITLE
feat: Support pnpm_version input

### DIFF
--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -56,7 +56,7 @@ on:
       environment:
         description: |
           Any required environment variables to set for the speakeasy run execution. Set as a string with each entry of the form "key=value".
-  
+
           Example: 
             environment: |
               SPECIFICATION_URL=https://api.example.com/swagger.json
@@ -74,6 +74,10 @@ on:
         required: false
         type: string
         default: "5.x"
+      pnpm_version:
+        description: "Version of pnpm to install. Not recommended for use without consulting Speakeasy support."
+        required: false
+        type: string
     secrets:
       github_access_token:
         description: A GitHub access token with write access to the repo
@@ -182,6 +186,7 @@ jobs:
           push_code_samples_only: ${{ inputs.push_code_samples }}
           set_version: ${{ inputs.set_version }}
           cli_environment_variables: ${{ inputs.environment }}
+          pnpm_version: ${{ inputs.pnpm_version }}
       - uses: ravsamhq/notify-slack-action@v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN apk add git
 
 ### Install Node / NPM
 RUN apk add --update --no-cache nodejs npm
-RUN npm install -g pnpm # install pnpm
 
 ### Install Python
 RUN apk add --update --no-cache python3 py3-pip python3-dev

--- a/action.yml
+++ b/action.yml
@@ -198,3 +198,4 @@ runs:
     - ${{ inputs.code_samples }}
     - ${{ inputs.set_version }}
     - ${{ inputs.cli_environment_variables }}
+    - ${{ inputs.pnpm_version }}

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,9 @@ inputs:
     description: |
       Extra environment variables to set for the speakeasy run execution.
     required: false
+  pnpm_version:
+    description: "Version of pnpm to install. Not recommended for use without consulting Speakeasy support."
+    required: false
 outputs:
   publish_python:
     description: "Whether the Python SDK will be published to PyPi"

--- a/internal/actions/runWorkflow.go
+++ b/internal/actions/runWorkflow.go
@@ -24,6 +24,10 @@ func RunWorkflow() error {
 		return err
 	}
 
+	if err := SetupEnvironment(); err != nil {
+		return fmt.Errorf("failed to setup environment: %w", err)
+	}
+
 	// The top-level CLI can always use latest. The CLI itself manages pinned versions.
 	resolvedVersion, err := cli.Download("latest", g)
 	if err != nil {

--- a/internal/actions/setup_environment.go
+++ b/internal/actions/setup_environment.go
@@ -1,0 +1,26 @@
+package actions
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/speakeasy-api/sdk-generation-action/internal/environment"
+)
+
+// SetupEnvironment will install runtime environment dependencies.
+//
+// For example if pnpm is desired instead of npm for target compilation and
+// publishing, then an input (pnpm_version in this case) should be set to a
+// non-empty value and this logic will install the dependency.
+func SetupEnvironment() error {
+	if pnpmVersion := environment.GetPnpmVersion(); pnpmVersion != "" {
+		pnpmPackageSpec := "pnpm@" + pnpmVersion
+		cmd := exec.Command("npm", "install", "-g", pnpmPackageSpec)
+
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("error installing %s: %w", pnpmPackageSpec, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -2,12 +2,13 @@ package environment
 
 import (
 	"fmt"
-	"github.com/joho/godotenv"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/joho/godotenv"
 )
 
 type Mode string
@@ -217,6 +218,10 @@ func GetOpenAPIDocAuthHeader() string {
 
 func GetOpenAPIDocAuthToken() string {
 	return os.Getenv("INPUT_OPENAPI_DOC_AUTH_TOKEN")
+}
+
+func GetPnpmVersion() string {
+	return os.Getenv("INPUT_PNPM_VERSION")
 }
 
 func GetWorkflowName() string {


### PR DESCRIPTION
This input enables pnpm to be globally installed into the Docker runtime. It is not recommended for use without consulting Speakeasy support.