### PR TITLE
feat: propogate CLI/Generation version from what was used by the CLI

### DIFF
--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       speakeasy_version:
-        description: The version of the Speakeasy CLI to use or "latest"
+        description: The version of the Speakeasy CLI to use or "latest" [DEPRECATED]
         default: latest
         required: false
         type: string

--- a/internal/actions/runWorkflow.go
+++ b/internal/actions/runWorkflow.go
@@ -98,18 +98,17 @@ func RunWorkflow() error {
 		}
 		return err
 	}
-	outputs["resolved_speakeasy_version"] = resolvedVersion
 
 	anythingRegenerated := false
 
 	if runRes.GenInfo != nil {
 		docVersion := runRes.GenInfo.OpenAPIDocVersion
-		speakeasyVersion := runRes.GenInfo.SpeakeasyVersion
+		resolvedVersion = runRes.GenInfo.SpeakeasyVersion
 
 		releaseInfo := releases.ReleasesInfo{
 			ReleaseTitle:       environment.GetInvokeTime().Format("2006-01-02 15:04:05"),
 			DocVersion:         docVersion,
-			SpeakeasyVersion:   speakeasyVersion,
+			SpeakeasyVersion:   resolvedVersion,
 			GenerationVersion:  runRes.GenInfo.GenerationVersion,
 			DocLocation:        environment.GetOpenAPIDocLocation(),
 			Languages:          map[string]releases.LanguageReleaseInfo{},
@@ -155,10 +154,12 @@ func RunWorkflow() error {
 			return err
 		}
 
-		if _, err := g.CommitAndPush(docVersion, speakeasyVersion, "", environment.ActionRunWorkflow, false); err != nil {
+		if _, err := g.CommitAndPush(docVersion, resolvedVersion, "", environment.ActionRunWorkflow, false); err != nil {
 			return err
 		}
 	}
+
+	outputs["resolved_speakeasy_version"] = resolvedVersion
 
 	if sourcesOnly {
 		if _, err := g.CommitAndPush("", resolvedVersion, "", environment.ActionRunWorkflow, sourcesOnly); err != nil {

--- a/internal/actions/runWorkflow.go
+++ b/internal/actions/runWorkflow.go
@@ -34,6 +34,7 @@ func RunWorkflow() error {
 		return err
 	}
 
+	// This flag is generally deprecated, it will not be provided on new action instances
 	pinnedVersion := cli.GetVersion(environment.GetPinnedSpeakeasyVersion())
 	if pinnedVersion != "latest" {
 		resolvedVersion = pinnedVersion

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -47,14 +47,16 @@ func Run(g Git, pr *github.PullRequest, wf *workflow.Workflow) (*RunResult, map[
 	workspace := environment.GetWorkspace()
 	outputs := map[string]string{}
 
-	speakeasyVersion, err := cli.GetSpeakeasyVersion()
+	executeSpeakeasyVersion, err := cli.GetSpeakeasyVersion()
 	if err != nil {
 		return nil, outputs, fmt.Errorf("failed to get speakeasy version: %w", err)
 	}
-	generationVersion, err := cli.GetGenerationVersion()
+	executeGenerationVersion, err := cli.GetGenerationVersion()
 	if err != nil {
 		return nil, outputs, fmt.Errorf("failed to get generation version: %w", err)
 	}
+	speakeasyVersion := executeSpeakeasyVersion.String()
+	generationVersion := executeGenerationVersion.String()
 
 	langGenerated := map[string]bool{}
 
@@ -186,6 +188,14 @@ func Run(g Git, pr *github.PullRequest, wf *workflow.Workflow) (*RunResult, map[
 
 		if dirty {
 			langGenerated[lang] = true
+			// Set speakeasy version and generation version to what was used by the CLI
+			if currentManagementInfo.SpeakeasyVersion != "" {
+				speakeasyVersion = currentManagementInfo.SpeakeasyVersion
+			}
+			if currentManagementInfo.GenerationVersion != "" {
+				generationVersion = currentManagementInfo.GenerationVersion
+			}
+
 			fmt.Printf("Regenerating %s SDK resulted in significant changes %s\n", lang, dirtyMsg)
 		} else {
 			fmt.Printf("Regenerating %s SDK did not result in any changes\n", lang)
@@ -215,8 +225,8 @@ func Run(g Git, pr *github.PullRequest, wf *workflow.Workflow) (*RunResult, map[
 
 	if regenerated {
 		genInfo = &GenerationInfo{
-			SpeakeasyVersion:  speakeasyVersion.String(),
-			GenerationVersion: generationVersion.String(),
+			SpeakeasyVersion:  speakeasyVersion,
+			GenerationVersion: generationVersion,
 			// OpenAPIDocVersion: docVersion, //TODO
 			Languages: langGenInfo,
 		}


### PR DESCRIPTION
If the CLI uses a specific speakeasyVersion and generationVersion to generate the SDK. That needs to be propogated back to Github so logs and releases entries are correct. The CLI determines what specific version is used to generate via workflow.yaml, not github.