### PR TITLE
feat: revert sdk gen config bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/pb33f/libopenapi v0.15.14
 	github.com/speakeasy-api/git-diff-parser v0.0.3
-	github.com/speakeasy-api/sdk-gen-config v1.23.4
+	github.com/speakeasy-api/sdk-gen-config v1.7.4
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.7.1
 	github.com/speakeasy-api/versioning-reports v0.6.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/skeema/knownhosts v1.2.1 h1:SHWdIUa82uGZz+F+47k8SY4QhhI291cXCpopT1lK2
 github.com/skeema/knownhosts v1.2.1/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/speakeasy-api/git-diff-parser v0.0.3 h1:LL12d+HMtSyj6O/hQqIn/lgDPYI6ci/DEhk0la/xA+0=
 github.com/speakeasy-api/git-diff-parser v0.0.3/go.mod h1:P46HmmVVmwA9P8h2wa0fDpmRM8/grbVQ+uKhWDtpkIY=
-github.com/speakeasy-api/sdk-gen-config v1.23.4 h1:qWzDHEWa36S6wf5Y4bdwP9S8f+DRYc6ekoHG8OyAKe4=
-github.com/speakeasy-api/sdk-gen-config v1.23.4/go.mod h1:e9PjnCRHGa4K4EFKVU+kKmihOZjJ2V4utcU+274+bnQ=
+github.com/speakeasy-api/sdk-gen-config v1.7.4 h1:hk3GaKiL6zxx3SulnxdunvU2V7bUSQ4YviXtIiUmWuo=
+github.com/speakeasy-api/sdk-gen-config v1.7.4/go.mod h1:4R+8FTyM6UdLHltOVAigIoR5D2UfPsGMmEFzPOP1yCs=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.7.1 h1:8cfPRFXn9a7IMBAQFhQ0N4rKCHMqWclVBGTEmXKXrZ4=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.7.1/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
 github.com/speakeasy-api/versioning-reports v0.6.0 h1:oLokEQ7xnDXqWAQk60Sk+ifwYaRbq3BrLX2KyT8gWxE=


### PR DESCRIPTION
This change is safe, but given we don't need to bump it anymore right now I would rather stage changes and not move forward a bunch of versions while we are changing other publishing things