### PR TITLE
feat: track GitHub PRs in CLI events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pb33f/libopenapi v0.15.14
 	github.com/speakeasy-api/git-diff-parser v0.0.3
 	github.com/speakeasy-api/sdk-gen-config v1.7.4
-	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.7.1
+	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.14.1
 	github.com/speakeasy-api/versioning-reports v0.6.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/speakeasy-api/git-diff-parser v0.0.3 h1:LL12d+HMtSyj6O/hQqIn/lgDPYI6c
 github.com/speakeasy-api/git-diff-parser v0.0.3/go.mod h1:P46HmmVVmwA9P8h2wa0fDpmRM8/grbVQ+uKhWDtpkIY=
 github.com/speakeasy-api/sdk-gen-config v1.7.4 h1:hk3GaKiL6zxx3SulnxdunvU2V7bUSQ4YviXtIiUmWuo=
 github.com/speakeasy-api/sdk-gen-config v1.7.4/go.mod h1:4R+8FTyM6UdLHltOVAigIoR5D2UfPsGMmEFzPOP1yCs=
-github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.7.1 h1:8cfPRFXn9a7IMBAQFhQ0N4rKCHMqWclVBGTEmXKXrZ4=
-github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.7.1/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
+github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.14.1 h1:85zERgXt3pNq1EX11j+2qNW8LqC1B5dsqoYjqOoMpoI=
+github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.14.1/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
 github.com/speakeasy-api/versioning-reports v0.6.0 h1:oLokEQ7xnDXqWAQk60Sk+ifwYaRbq3BrLX2KyT8gWxE=
 github.com/speakeasy-api/versioning-reports v0.6.0/go.mod h1:LW5FABrvi5SBbeiD3HJYw0JZYe6Rw2Xna59pFJ2BmLI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/actions/runWorkflow.go
+++ b/internal/actions/runWorkflow.go
@@ -62,6 +62,7 @@ func RunWorkflow() error {
 		if err != nil {
 			return err
 		}
+		
 		if pr != nil {
 			os.Setenv("GH_PULL_REQUEST", *pr.URL)
 		}

--- a/internal/actions/runWorkflow.go
+++ b/internal/actions/runWorkflow.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/google/go-github/v63/github"
@@ -60,6 +61,9 @@ func RunWorkflow() error {
 		branchName, pr, err = g.FindExistingPR("", environment.ActionRunWorkflow, sourcesOnly)
 		if err != nil {
 			return err
+		}
+		if pr != nil {
+			os.Setenv("GH_PULL_REQUEST", *pr.URL)
 		}
 	}
 
@@ -253,6 +257,11 @@ func finalize(inputs finalizeInputs) error {
 		}); err != nil {
 			return err
 		}
+
+		if pr != nil {
+			os.Setenv("GH_PULL_REQUEST", *pr.URL)
+		}
+
 	case environment.ModeDirect:
 		var releaseInfo *releases.ReleasesInfo
 		if !inputs.SourcesOnly {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -63,12 +63,6 @@ func EnrichEventWithEnvironmentVariables(event *shared.CliEvent) {
 	if ghActionVersion != "" {
 		event.GhActionVersion = &ghActionVersion
 	}
-
-	ghPullRequest := os.Getenv("GH_PULL_REQUEST")
-
-	if ghPullRequest != "" {
-		event.GhPullRequest = &ghPullRequest
-	}
 }
 
 func enrichHostName(event *shared.CliEvent) {
@@ -129,6 +123,13 @@ func Track(ctx context.Context, exec shared.InteractionType, fn func(ctx context
 
 	// Execute the provided function, capturing any error
 	err = fn(ctx, runEvent)
+
+	// Populate event with pull request env var (available only after run)
+	ghPullRequest := os.Getenv("GH_PULL_REQUEST")
+
+	if ghPullRequest != "" {
+		runEvent.GhPullRequest = &ghPullRequest
+	}
 
 	// Update the event with completion details
 	curTime := time.Now()

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -63,6 +63,12 @@ func EnrichEventWithEnvironmentVariables(event *shared.CliEvent) {
 	if ghActionVersion != "" {
 		event.GhActionVersion = &ghActionVersion
 	}
+
+	ghPullRequest := os.Getenv("GH_PULL_REQUEST")
+
+	if ghPullRequest != "" {
+		event.GhPullRequest = &ghPullRequest
+	}
 }
 
 func enrichHostName(event *shared.CliEvent) {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -39,7 +39,7 @@ func NewContextWithSDK(ctx context.Context, apiKey string) (context.Context, *sp
 	sdkWithWorkspace := speakeasy.New(speakeasy.WithSecurity(security), speakeasy.WithWorkspaceID(validated.APIKeyDetails.WorkspaceID))
 	ctx = context.WithValue(ctx, SpeakeasySDKKey, sdkWithWorkspace)
 	ctx = context.WithValue(ctx, WorkspaceIDKey, validated.APIKeyDetails.WorkspaceID)
-	ctx = context.WithValue(ctx, AccountTypeKey, validated.APIKeyDetails.AccountType)
+	ctx = context.WithValue(ctx, AccountTypeKey, validated.APIKeyDetails.AccountTypeV2)
 	return ctx, sdkWithWorkspace, validated.APIKeyDetails.WorkspaceID, err
 }
 
@@ -138,9 +138,9 @@ func Track(ctx context.Context, exec shared.InteractionType, fn func(ctx context
 	runEvent.ContinuousIntegrationEnvironment = &currentIntegrationEnvironment
 
 	// Attempt to flush any stored events (swallow errors)
-	sdk.Events.PostWorkspaceEvents(ctx, operations.PostWorkspaceEventsRequest{
+	sdk.Events.Post(ctx, operations.PostWorkspaceEventsRequest{
 		RequestBody: []shared.CliEvent{*runEvent},
-		WorkspaceID: &workspaceID,
+		WorkspaceID: workspaceID,
 	})
 
 	return err


### PR DESCRIPTION
Collects the GitHub PR URL (when applicable) and adds it to the event telemetry (again when applicable).