### PR TITLE
feat: support label based versioning

### DIFF
--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -179,7 +179,7 @@ jobs:
           # Check if the label is a valid version bump and ensure the current PR isn't already on that version bump
           # If either are true we short circuit the rest of the action
           if [[ "$label" != "patch" && "$label" != "minor" && "$label" != "major" && "$label" != "graduate" ]] || grep -Fq "Version Bump Type: [$label]" "$tmpfile"; then
-            echo "Invalid label or conflicting label found in PR body. Short-circuiting."
+            echo "No version bump label found in PR body. Short-circuiting."
             echo "short_circuit_label_trigger=true" >> "$GITHUB_OUTPUT"
             exit 0
           else

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -191,7 +191,7 @@ jobs:
       - id: run-workflow
         name: Run Generation Workflow
         if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true' }}
-        uses: speakeasy-api/sdk-generation-action@v15.32.6
+        uses: speakeasy-api/sdk-generation-action@v15
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -166,7 +166,6 @@ jobs:
       resolved_speakeasy_version: ${{ steps.run-workflow.outputs.resolved_speakeasy_version }}
       use_sonatype_legacy: ${{ steps.run-workflow.outputs.use_sonatype_legacy }}
     steps:
-      -
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: run-workflow

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -170,7 +170,7 @@ jobs:
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: run-workflow
         name: Run Generation Workflow
-        uses: speakeasy-api/sdk-generation-action@v15
+        uses: speakeasy-api/sdk-generation-action@v15.32.6
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -165,27 +165,34 @@ jobs:
       branch_name: ${{ steps.run-workflow.outputs.branch_name }}
       resolved_speakeasy_version: ${{ steps.run-workflow.outputs.resolved_speakeasy_version }}
       use_sonatype_legacy: ${{ steps.run-workflow.outputs.use_sonatype_legacy }}
-      short_circuit_label_trigger: ${{ steps.check-label.outputs.short_circuit_label_trigger || 'false' }}
+      short_circuit_label_trigger: ${{ steps.check-label.outputs.short_circuit_label_trigger }}
     steps:
       - name: Check Pull Request Label
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' }}
         id: check-label
         run: |
+          # Capture the label and PR body in variables
           label="${{ github.event.label.name }}"
-          pr_body="${{ github.event.pull_request.body }}"
-          if [[ "$label" != "patch" && "$label" != "minor" && "$label" != "major" && "$label" != "graduate" ]] || [[ "$pr_body" == *"Version Bump Type: [$label]"* ]]; then
-            echo "Invalid label or label found in PR body. Short-circuiting."
+
+          # Create a temporary file for the PR body to safely handle special characters
+          tmpfile=$(mktemp)
+          echo "${{ github.event.pull_request.body }}" > "$tmpfile"
+
+          # Check if the label is valid or if the PR body contains the specific version bump pattern
+          if [[ "$label" != "patch" && "$label" != "minor" && "$label" != "major" && "$label" != "graduate" ]] || grep -Fq "Version Bump Type: [$label]" "$tmpfile"; then
+            echo "Invalid label or conflicting label found in PR body. Short-circuiting."
             echo "::set-output name=short_circuit_label_trigger::true"
             exit 0
           else
-          echo "Valid label and no PR body conflict."
-          echo "::set-output name=short_circuit_label_trigger::false"
+            echo "Valid label and no conflict in PR body."
+            echo "::set-output name=short_circuit_label_trigger::false"
           fi
       - name: Tune GitHub-hosted runner network
+        if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true' }}
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: run-workflow
         name: Run Generation Workflow
-        if: ${{ steps.check-label.outputs.short_circuit_label_trigger == 'false' }}
+        if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true' }}
         uses: speakeasy-api/sdk-generation-action@v15.32.6
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
@@ -204,7 +211,7 @@ jobs:
           cli_environment_variables: ${{ inputs.environment }}
           pnpm_version: ${{ inputs.pnpm_version }}
       - uses: ravsamhq/notify-slack-action@v2
-        if: ${{ steps.check-label.outputs.short_circuit_label_trigger == 'false' && env.SLACK_WEBHOOK_URL != '' }}
+        if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true' && env.SLACK_WEBHOOK_URL != '' }}
         with:
           status: ${{ job.status }}
           token: ${{ secrets.github_access_token }}
@@ -217,7 +224,7 @@ jobs:
       - id: log-result
         name: Log Generation Output
         uses: speakeasy-api/sdk-generation-action@v15
-        if: ${{ steps.check-label.outputs.short_circuit_label_trigger == 'false'}}
+        if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true'}}
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -170,22 +170,20 @@ jobs:
       - name: Check Pull Request Label
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' }}
         id: check-label
+        continue-on-error: true
         run: |
-          # Capture the label and PR body in variables
           label="${{ github.event.label.name }}"
-
-          # Create a temporary file for the PR body to safely handle special characters
           tmpfile=$(mktemp)
           echo "${{ github.event.pull_request.body }}" > "$tmpfile"
 
-          # Check if the label is valid or if the PR body contains the specific version bump pattern
+          # Check if the label is a valid version bump and ensure the current PR isn't already on that version bump
+          # If either are true we short circuit the rest of the action
           if [[ "$label" != "patch" && "$label" != "minor" && "$label" != "major" && "$label" != "graduate" ]] || grep -Fq "Version Bump Type: [$label]" "$tmpfile"; then
             echo "Invalid label or conflicting label found in PR body. Short-circuiting."
-            echo "::set-output name=short_circuit_label_trigger::true"
+            echo "short_circuit_label_trigger=true" >> "$GITHUB_OUTPUT"
             exit 0
           else
-            echo "Valid label and no conflict in PR body."
-            echo "::set-output name=short_circuit_label_trigger::false"
+            echo "short_circuit_label_trigger=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Tune GitHub-hosted runner network
         if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true' }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -166,6 +166,7 @@ jobs:
       resolved_speakeasy_version: ${{ steps.run-workflow.outputs.resolved_speakeasy_version }}
       use_sonatype_legacy: ${{ steps.run-workflow.outputs.use_sonatype_legacy }}
     steps:
+      -
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: run-workflow

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -165,11 +165,27 @@ jobs:
       branch_name: ${{ steps.run-workflow.outputs.branch_name }}
       resolved_speakeasy_version: ${{ steps.run-workflow.outputs.resolved_speakeasy_version }}
       use_sonatype_legacy: ${{ steps.run-workflow.outputs.use_sonatype_legacy }}
+      short_circuit_label_trigger: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' && steps.check-label.outputs.short_circuit_label_trigger == 'true' }}
     steps:
+      - name: Check Pull Request Label
+        if: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' }}
+        id: check-label
+        run: |
+          label=$(echo "${{ github.event.label.name }}" | tr '[:upper:]' '[:lower:]')
+          pr_body="${{ github.event.pull_request.body }}"
+          if [[ "$label" != "patch" && "$label" != "minor" && "$label" != "major" && "$label" != "graduate" ]] || [[ "$pr_body" == *"Version Bump Type: [$label]"* ]]; then
+            echo "Invalid label or label found in PR body. Short-circuiting."
+            echo "::set-output name=short_circuit_label_trigger::true"
+            exit 0
+          else
+          echo "Valid label and no PR body conflict."
+          echo "::set-output name=short_circuit_label_trigger::false"
+          fi
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1
       - id: run-workflow
         name: Run Generation Workflow
+        if: ${{ steps.check-label.outputs.short_circuit_label_trigger == 'false' }}
         uses: speakeasy-api/sdk-generation-action@v15.32.6
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
@@ -188,7 +204,7 @@ jobs:
           cli_environment_variables: ${{ inputs.environment }}
           pnpm_version: ${{ inputs.pnpm_version }}
       - uses: ravsamhq/notify-slack-action@v2
-        if: always() && env.SLACK_WEBHOOK_URL != ''
+        if: ${{ steps.check-label.outputs.short_circuit_label_trigger == 'false' && env.SLACK_WEBHOOK_URL != '' }}
         with:
           status: ${{ job.status }}
           token: ${{ secrets.github_access_token }}
@@ -201,7 +217,7 @@ jobs:
       - id: log-result
         name: Log Generation Output
         uses: speakeasy-api/sdk-generation-action@v15
-        if: always()
+        if: ${{ steps.check-label.outputs.short_circuit_label_trigger == 'false'}}
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -165,13 +165,13 @@ jobs:
       branch_name: ${{ steps.run-workflow.outputs.branch_name }}
       resolved_speakeasy_version: ${{ steps.run-workflow.outputs.resolved_speakeasy_version }}
       use_sonatype_legacy: ${{ steps.run-workflow.outputs.use_sonatype_legacy }}
-      short_circuit_label_trigger: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' && steps.check-label.outputs.short_circuit_label_trigger == 'true' }}
+      short_circuit_label_trigger: ${{ steps.check-label.outputs.short_circuit_label_trigger || 'false' }}
     steps:
       - name: Check Pull Request Label
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' }}
         id: check-label
         run: |
-          label=$(echo "${{ github.event.label.name }}" | tr '[:upper:]' '[:lower:]')
+          label="${{ github.event.label.name | toLower }}"
           pr_body="${{ github.event.pull_request.body }}"
           if [[ "$label" != "patch" && "$label" != "minor" && "$label" != "major" && "$label" != "graduate" ]] || [[ "$pr_body" == *"Version Bump Type: [$label]"* ]]; then
             echo "Invalid label or label found in PR body. Short-circuiting."

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -171,7 +171,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' }}
         id: check-label
         run: |
-          label="${{ github.event.label.name | toLower }}"
+          label="${{ github.event.label.name }}"
           pr_body="${{ github.event.pull_request.body }}"
           if [[ "$label" != "patch" && "$label" != "minor" && "$label" != "major" && "$label" != "graduate" ]] || [[ "$pr_body" == *"Version Bump Type: [$label]"* ]]; then
             echo "Invalid label or label found in PR body. Short-circuiting."

--- a/action.yml
+++ b/action.yml
@@ -169,7 +169,7 @@ outputs:
     description: "The directory the SDK target was generated to"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15"
+  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.32.6"
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}

--- a/action.yml
+++ b/action.yml
@@ -169,7 +169,7 @@ outputs:
     description: "The directory the SDK target was generated to"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.32.6"
+  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15"
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}

--- a/internal/actions/runWorkflow.go
+++ b/internal/actions/runWorkflow.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v63/github"
+	"github.com/speakeasy-api/sdk-generation-action/internal/versionbumps"
 	"github.com/speakeasy-api/versioning-reports/versioning"
 
 	"github.com/speakeasy-api/sdk-generation-action/internal/configuration"
@@ -186,7 +187,7 @@ func RunWorkflow() error {
 		AnythingRegenerated:  anythingRegenerated,
 		SourcesOnly:          sourcesOnly,
 		Git:                  g,
-		VersioningReport:     runRes.VersioningReport,
+		VersioningInfo:       runRes.VersioningInfo,
 		LintingReportURL:     runRes.LintingReportURL,
 		ChangesReportURL:     runRes.ChangesReportURL,
 		OpenAPIChangeSummary: runRes.OpenAPIChangeSummary,
@@ -215,6 +216,7 @@ type finalizeInputs struct {
 	ChangesReportURL     string
 	OpenAPIChangeSummary string
 	VersioningReport     *versioning.MergedVersionReport
+	VersioningInfo       versionbumps.VersioningInfo
 	currentRelease       *releases.ReleasesInfo
 }
 
@@ -253,7 +255,7 @@ func finalize(inputs finalizeInputs) error {
 			SourceGeneration:     inputs.SourcesOnly,
 			LintingReportURL:     inputs.LintingReportURL,
 			ChangesReportURL:     inputs.ChangesReportURL,
-			VersioningReport:     inputs.VersioningReport,
+			VersioningInfo:       inputs.VersioningInfo,
 			OpenAPIChangeSummary: inputs.OpenAPIChangeSummary,
 		})
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -53,7 +53,7 @@ func GetSupportedLanguages() []string {
 			return supportedTargets
 		}
 	}
-	
+
 	return defaultSupportedTargets
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -7,15 +7,12 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/speakeasy-api/sdk-generation-action/internal/registry"
-	"golang.org/x/exp/slices"
-
 	"github.com/speakeasy-api/sdk-generation-action/internal/environment"
+	"github.com/speakeasy-api/sdk-generation-action/internal/registry"
+	"github.com/speakeasy-api/versioning-reports/versioning"
 )
 
 const BumpOverrideEnvVar = "SPEAKEASY_BUMP_OVERRIDE"
-
-var validLabelOverrides = []string{"graduate", "major", "minor", "patch"}
 
 type RunResults struct {
 	LintingReportURL     string
@@ -23,7 +20,7 @@ type RunResults struct {
 	OpenAPIChangeSummary string
 }
 
-func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, repoSubdirectories map[string]string) (*RunResults, error) {
+func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, repoSubdirectories map[string]string, manualVersionBump *versioning.BumpType) (*RunResults, error) {
 	args := []string{
 		"run",
 	}
@@ -69,10 +66,8 @@ func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, r
 		os.Setenv("SPEAKEASY_FORCE_GENERATION", "true")
 	}
 
-	fmt.Println("EVENT WORKFLOW LABEL")
-	fmt.Println(environment.GetWorkflowEventLabelName())
-	if label := environment.GetWorkflowEventLabelName(); slices.Contains(validLabelOverrides, label) {
-		os.Setenv(BumpOverrideEnvVar, label)
+	if manualVersionBump != nil {
+		os.Setenv(BumpOverrideEnvVar, string(*manualVersionBump))
 	}
 
 	//if environment.ShouldOutputTests() {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -8,9 +8,14 @@ import (
 	"strings"
 
 	"github.com/speakeasy-api/sdk-generation-action/internal/registry"
+	"golang.org/x/exp/slices"
 
 	"github.com/speakeasy-api/sdk-generation-action/internal/environment"
 )
+
+const BumpOverrideEnvVar = "SPEAKEASY_BUMP_OVERRIDE"
+
+var validLabelOverrides = []string{"graduate", "major", "minor", "patch"}
 
 type RunResults struct {
 	LintingReportURL     string
@@ -62,6 +67,12 @@ func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, r
 	if environment.ForceGeneration() {
 		fmt.Println("\nforce input enabled - setting SPEAKEASY_FORCE_GENERATION=true")
 		os.Setenv("SPEAKEASY_FORCE_GENERATION", "true")
+	}
+
+	fmt.Println("EVENT WORKFLOW LABEL")
+	fmt.Println(environment.GetWorkflowEventLabelName())
+	if label := environment.GetWorkflowEventLabelName(); slices.Contains(validLabelOverrides, label) {
+		os.Setenv(BumpOverrideEnvVar, label)
 	}
 
 	//if environment.ShouldOutputTests() {

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -238,6 +238,10 @@ func GetCliOutput() string {
 }
 
 func GetRef() string {
+	// handle pr based action triggers
+	if strings.Contains(os.Getenv("GITHUB_REF"), "pulls/") {
+		return os.Getenv("GITHUB_HEAD_REF")
+	}
 	return os.Getenv("GITHUB_REF")
 }
 

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -225,6 +225,10 @@ func GetWorkflowEventPayloadPath() string {
 	return os.Getenv("GITHUB_EVENT_PATH")
 }
 
+func GetWorkflowEventLabelName() string {
+	return os.Getenv("GITHUB_EVENT_LABEL_NAME")
+}
+
 func GetBranchName() string {
 	return os.Getenv("INPUT_BRANCH_NAME")
 }

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -3,6 +3,7 @@ package environment
 import (
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -239,7 +240,7 @@ func GetCliOutput() string {
 
 func GetRef() string {
 	// handle pr based action triggers
-	if strings.Contains(os.Getenv("GITHUB_REF"), "pulls/") {
+	if slices.Contains([]string{"refs/pull", "refs/pulls"}, os.Getenv("GITHUB_REF")) {
 		return os.Getenv("GITHUB_HEAD_REF")
 	}
 	return os.Getenv("GITHUB_REF")

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -240,7 +240,7 @@ func GetCliOutput() string {
 func GetRef() string {
 	// handle pr based action triggers
 	if strings.Contains(os.Getenv("GITHUB_REF"), "refs/pull") || strings.Contains(os.Getenv("GITHUB_REF"), "refs/pulls") {
-		return os.Getenv("GITHUB_HEAD_REF")
+		return os.Getenv("GITHUB_BASE_REF")
 	}
 	return os.Getenv("GITHUB_REF")
 }

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -3,7 +3,6 @@ package environment
 import (
 	"fmt"
 	"os"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -240,7 +239,7 @@ func GetCliOutput() string {
 
 func GetRef() string {
 	// handle pr based action triggers
-	if slices.Contains([]string{"refs/pull", "refs/pulls"}, os.Getenv("GITHUB_REF")) {
+	if strings.Contains(os.Getenv("GITHUB_REF"), "refs/pull") || strings.Contains(os.Getenv("GITHUB_REF"), "refs/pulls") {
 		return os.Getenv("GITHUB_HEAD_REF")
 	}
 	return os.Getenv("GITHUB_REF")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -541,11 +541,15 @@ Based on:
 
 		// We keep track of explicit bump types and whether that bump type is manual or automated in the PR body
 		if labelBumpType != nil {
-			bumpMethod := versionbumps.BumpMethodAutomated
+			versionBumpMsg := "Version Bump Type: " + fmt.Sprintf("[%s]", string(*labelBumpType)) + " - "
 			if info.VersioningInfo.ManualBump {
-				bumpMethod = versionbumps.BumpMethodManual
+				versionBumpMsg += string(versionbumps.BumpMethodManual)
+				// if manual we bold the message
+				versionBumpMsg = "**" + versionBumpMsg + "**"
+			} else {
+				versionBumpMsg += string(versionbumps.BumpMethodAutomated)
 			}
-			body += "\n\nVersion Bump Type: " + string(*labelBumpType) + " " + fmt.Sprintf("[%s]", string(bumpMethod))
+			body += "\n\n" + versionBumpMsg
 		}
 
 	} else {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -61,7 +61,7 @@ func (g *Git) CloneRepo() error {
 		return fmt.Errorf("failed to construct repo url: %w", err)
 	}
 
-	ref := os.Getenv("GITHUB_REF")
+	ref := environment.GetRef()
 
 	logging.Info("Cloning repo: %s from ref: %s", repoPath, ref)
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -571,6 +571,7 @@ Based on:
 		info.PR.Body = github.String(body)
 		info.PR.Title = &title
 		info.PR, _, err = g.client.PullRequests.Edit(context.Background(), os.Getenv("GITHUB_REPOSITORY_OWNER"), getRepo(), info.PR.GetNumber(), info.PR)
+		// Set labels MUST always follow updating the PR
 		g.setPRLabels(context.Background(), os.Getenv("GITHUB_REPOSITORY_OWNER"), getRepo(), info.PR.GetNumber(), labelTypes, info.PR.Labels, labels)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update PR: %w", err)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -541,13 +541,14 @@ Based on:
 
 		// We keep track of explicit bump types and whether that bump type is manual or automated in the PR body
 		if labelBumpType != nil {
+			// be very careful if changing this it critically aligns with a regex in parseBumpFromPRBody
 			versionBumpMsg := "Version Bump Type: " + fmt.Sprintf("[%s]", string(*labelBumpType)) + " - "
 			if info.VersioningInfo.ManualBump {
-				versionBumpMsg += string(versionbumps.BumpMethodManual)
+				versionBumpMsg += string(versionbumps.BumpMethodManual) + " (manual)"
 				// if manual we bold the message
 				versionBumpMsg = "**" + versionBumpMsg + "**"
 			} else {
-				versionBumpMsg += string(versionbumps.BumpMethodAutomated)
+				versionBumpMsg += string(versionbumps.BumpMethodAutomated) + " (automated)"
 			}
 			body += "\n\n" + versionBumpMsg
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -547,6 +547,7 @@ Based on:
 				versionBumpMsg += string(versionbumps.BumpMethodManual) + " (manual)"
 				// if manual we bold the message
 				versionBumpMsg = "**" + versionBumpMsg + "**"
+				versionBumpMsg += fmt.Sprintf("\nThis PR will stay on the current version until the %s label is removed and/or modified", string(*labelBumpType))
 			} else {
 				versionBumpMsg += string(versionbumps.BumpMethodAutomated) + " (automated)"
 			}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -545,7 +545,7 @@ Based on:
 			if info.VersioningInfo.ManualBump {
 				bumpMethod = versionbumps.BumpMethodManual
 			}
-			body += "\n\nVersion Bump Type: " + string(*labelBumpType) + " " + string(bumpMethod)
+			body += "\n\nVersion Bump Type: " + string(*labelBumpType) + " " + fmt.Sprintf("[%s]", string(bumpMethod))
 		}
 
 	} else {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -16,8 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/speakeasy-api/versioning-reports/versioning"
-
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -28,6 +26,7 @@ import (
 	"github.com/speakeasy-api/sdk-generation-action/internal/cli"
 	"github.com/speakeasy-api/sdk-generation-action/internal/environment"
 	"github.com/speakeasy-api/sdk-generation-action/internal/logging"
+	"github.com/speakeasy-api/sdk-generation-action/internal/versionbumps"
 	"github.com/speakeasy-api/sdk-generation-action/pkg/releases"
 
 	"github.com/google/go-github/v63/github"
@@ -426,7 +425,7 @@ type PRInfo struct {
 	LintingReportURL     string
 	ChangesReportURL     string
 	OpenAPIChangeSummary string
-	VersioningReport     *versioning.MergedVersionReport
+	VersioningInfo       versionbumps.VersioningInfo
 }
 
 func (g *Git) CreateOrUpdatePR(info PRInfo) (*github.PullRequest, error) {
@@ -442,7 +441,7 @@ func (g *Git) CreateOrUpdatePR(info PRInfo) (*github.PullRequest, error) {
 	}
 
 	// Deprecated -- kept around for old CLI versions. VersioningReport is newer pathway
-	if info.ReleaseInfo != nil && info.VersioningReport == nil {
+	if info.ReleaseInfo != nil && info.VersioningInfo.VersionReport == nil {
 		for language, genInfo := range info.ReleaseInfo.LanguagesGenerated {
 			genPath := path.Join(environment.GetWorkspace(), "repo", genInfo.Path)
 
@@ -500,6 +499,16 @@ func (g *Git) CreateOrUpdatePR(info PRInfo) (*github.PullRequest, error) {
 		}
 	}
 
+	title := getGenPRTitlePrefix()
+	if environment.IsDocsGeneration() {
+		title = getDocsPRTitlePrefix()
+	} else if info.SourceGeneration {
+		title = getGenSourcesTitlePrefix()
+	}
+
+	suffix, labelBumpType, labels := PRVersionMetadata(info.VersioningInfo.VersionReport, labelTypes)
+	title += suffix
+
 	body := ""
 
 	if info.LintingReportURL != "" || info.ChangesReportURL != "" {
@@ -527,8 +536,18 @@ Based on:
 `, info.ReleaseInfo.DocVersion, info.ReleaseInfo.DocLocation, info.ReleaseInfo.SpeakeasyVersion, info.ReleaseInfo.GenerationVersion)
 	}
 
-	if info.VersioningReport != nil {
-		body += stripCodes(info.VersioningReport.GetMarkdownSection())
+	if info.VersioningInfo.VersionReport != nil {
+		body += stripCodes(info.VersioningInfo.VersionReport.GetMarkdownSection())
+
+		// We keep track of explicit bump types and whether that bump type is manual or automated in the PR body
+		if labelBumpType != nil {
+			bumpMethod := versionbumps.BumpMethodAutomated
+			if info.VersioningInfo.ManualBump {
+				bumpMethod = versionbumps.BumpMethodManual
+			}
+			body += "\n\nVersion Bump Type: " + string(*labelBumpType) + " " + string(bumpMethod)
+		}
+
 	} else {
 		if len(info.OpenAPIChangeSummary) > 0 {
 			body += fmt.Sprintf(`## OpenAPI Change Summary
@@ -545,14 +564,6 @@ Based on:
 	if len(body) > maxBodyLength {
 		body = body[:maxBodyLength-3] + "..."
 	}
-	title := getGenPRTitlePrefix()
-	if environment.IsDocsGeneration() {
-		title = getDocsPRTitlePrefix()
-	} else if info.SourceGeneration {
-		title = getGenSourcesTitlePrefix()
-	}
-	suffix, labels := PRMetadata(info.VersioningReport, labelTypes)
-	title += suffix
 
 	if info.PR != nil {
 		logging.Info("Updating PR")
@@ -593,57 +604,6 @@ Based on:
 	logging.Info("PR: %s", url)
 
 	return info.PR, nil
-}
-
-func (g *Git) setPRLabels(background context.Context, owner string, repo string, issueNumber int, labelTypes map[string]github.Label, actualLabels, desiredLabels []*github.Label) {
-	shouldRemove := []string{}
-	shouldAdd := []string{}
-	fmt.Println("LABELS")
-	fmt.Println(actualLabels)
-	fmt.Println(desiredLabels)
-	for _, label := range actualLabels {
-		foundInDesired := false
-		for _, desired := range desiredLabels {
-			if label.GetName() == desired.GetName() {
-				foundInDesired = true
-				break
-			}
-			if _, ok := labelTypes[label.GetName()]; !ok {
-				foundInDesired = true
-				continue
-			}
-			break
-		}
-		if !foundInDesired {
-			shouldRemove = append(shouldRemove, label.GetName())
-		}
-	}
-	for _, desired := range desiredLabels {
-		foundInActual := false
-		for _, label := range actualLabels {
-			if label.GetName() == desired.GetName() {
-				foundInActual = true
-				break
-			}
-		}
-		if !foundInActual {
-			shouldAdd = append(shouldAdd, desired.GetName())
-		}
-	}
-	if len(shouldAdd) > 0 {
-		_, _, err := g.client.Issues.AddLabelsToIssue(background, owner, repo, issueNumber, shouldAdd)
-		if err != nil {
-			logging.Info("failed to add labels %v: %s", shouldAdd, err.Error())
-		}
-	}
-	if len(shouldRemove) > 0 {
-		for _, label := range shouldRemove {
-			_, err := g.client.Issues.RemoveLabelForIssue(background, owner, repo, issueNumber, label)
-			if err != nil {
-				logging.Info("failed to remove labels %s: %s", label, err.Error())
-			}
-		}
-	}
 }
 
 func notEquivalent(desired []*github.Label, actual []*github.Label) bool {
@@ -727,45 +687,6 @@ Based on:
 	logging.Info("PR: %s", url)
 
 	return nil
-}
-
-func PRMetadata(m *versioning.MergedVersionReport, labelTypes map[string]github.Label) (string, []*github.Label) {
-	if m == nil {
-		return "", []*github.Label{}
-	}
-	labels := []*github.Label{}
-	skipBumpType := false
-	skipVersionNumber := false
-	singleBumpType := ""
-	singleNewVersion := ""
-	for _, report := range m.Reports {
-		if len(report.BumpType) > 0 && report.BumpType != versioning.BumpNone && report.BumpType != versioning.BumpCustom {
-			if len(singleBumpType) > 0 {
-				skipBumpType = true
-			}
-			singleBumpType = string(report.BumpType)
-		}
-		if len(report.NewVersion) > 0 {
-			if len(singleNewVersion) > 0 {
-				skipVersionNumber = true
-			}
-			singleNewVersion = report.NewVersion
-		}
-	}
-	var builder []string
-	if !skipVersionNumber {
-		builder = append(builder, singleNewVersion)
-	}
-	if !skipBumpType {
-		if matched, ok := labelTypes[singleBumpType]; ok {
-			labels = append(labels, &matched)
-		}
-	}
-	// Add an extra " " at front
-	if len(builder) > 0 {
-		builder = append([]string{""}, builder...)
-	}
-	return strings.Join(builder, " "), labels
 }
 
 func (g *Git) CreateSuggestionPR(branchName, output string) (*int, string, error) {
@@ -1055,51 +976,6 @@ func (g *Git) CreateTag(tag string, hash string) error {
 
 	logging.Info("Tag %s created for commit %s", tag, hash)
 	return nil
-}
-
-func (g *Git) UpsertLabelTypes(ctx context.Context) map[string]github.Label {
-	desiredLabels := map[string]github.Label{}
-	addGitHubLabel := func(name, description string) {
-		desiredLabels[name] = github.Label{
-			Name:        &name,
-			Description: &description,
-		}
-	}
-	addGitHubLabel(string(versioning.BumpMajor), "Major version bump")
-	addGitHubLabel(string(versioning.BumpMinor), "Minor version bump")
-	addGitHubLabel(string(versioning.BumpPatch), "Patch version bump")
-	addGitHubLabel(string(versioning.BumpGraduate), "Graduate prerelease to stable")
-	addGitHubLabel(string(versioning.BumpPrerelease), "Bump by a prerelease version")
-	actualLabels := make(map[string]github.Label)
-	allLabels, _, err := g.client.Issues.ListLabels(ctx, os.Getenv("GITHUB_REPOSITORY_OWNER"), getRepo(), nil)
-	if err != nil {
-		return actualLabels
-	}
-	for _, label := range allLabels {
-		actualLabels[*label.Name] = *label
-	}
-
-	for _, label := range desiredLabels {
-		foundLabel, ok := actualLabels[*label.Name]
-		if ok {
-			if *foundLabel.Description != *label.Description {
-				_, _, err = g.client.Issues.EditLabel(ctx, os.Getenv("GITHUB_REPOSITORY_OWNER"), getRepo(), *label.Name, &github.Label{
-					Name:        label.Name,
-					Description: label.Description,
-				})
-				if err != nil {
-					return actualLabels
-				}
-			}
-		} else {
-			_, _, err = g.client.Issues.CreateLabel(ctx, os.Getenv("GITHUB_REPOSITORY_OWNER"), getRepo(), &label)
-			if err != nil {
-				return actualLabels
-			}
-		}
-		actualLabels[*label.Name] = label
-	}
-	return actualLabels
 }
 
 func getGithubAuth(accessToken string) *gitHttp.BasicAuth {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -598,6 +598,9 @@ Based on:
 func (g *Git) setPRLabels(background context.Context, owner string, repo string, issueNumber int, labelTypes map[string]github.Label, actualLabels, desiredLabels []*github.Label) {
 	shouldRemove := []string{}
 	shouldAdd := []string{}
+	fmt.Println("LABELS")
+	fmt.Println(actualLabels)
+	fmt.Println(desiredLabels)
 	for _, label := range actualLabels {
 		foundInDesired := false
 		for _, desired := range desiredLabels {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -547,7 +547,7 @@ Based on:
 				versionBumpMsg += string(versionbumps.BumpMethodManual) + " (manual)"
 				// if manual we bold the message
 				versionBumpMsg = "**" + versionBumpMsg + "**"
-				versionBumpMsg += fmt.Sprintf("\nThis PR will stay on the current version until the %s label is removed and/or modified", string(*labelBumpType))
+				versionBumpMsg += fmt.Sprintf("\n\nThis PR will stay on the current version until the %s label is removed and/or modified.", string(*labelBumpType))
 			} else {
 				versionBumpMsg += string(versionbumps.BumpMethodAutomated) + " (automated)"
 			}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -247,7 +247,6 @@ func TestArtifactMatchesRelease(t *testing.T) {
 			goarch:    "amd",
 			want:      false,
 		},
-
 	}
 
 	for _, tt := range tests {

--- a/internal/git/labels.go
+++ b/internal/git/labels.go
@@ -1,0 +1,147 @@
+package git
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/google/go-github/v63/github"
+	"github.com/speakeasy-api/sdk-generation-action/internal/logging"
+	"github.com/speakeasy-api/sdk-generation-action/internal/versionbumps"
+	"github.com/speakeasy-api/versioning-reports/versioning"
+)
+
+func (g *Git) UpsertLabelTypes(ctx context.Context) map[string]github.Label {
+	desiredLabels := map[string]github.Label{}
+	addGitHubLabel := func(name, description string) {
+		desiredLabels[name] = github.Label{
+			Name:        &name,
+			Description: &description,
+		}
+	}
+	for bumpType, description := range versionbumps.GetBumpTypeLabels() {
+		addGitHubLabel(string(bumpType), description)
+	}
+
+	actualLabels := make(map[string]github.Label)
+	allLabels, _, err := g.client.Issues.ListLabels(ctx, os.Getenv("GITHUB_REPOSITORY_OWNER"), getRepo(), nil)
+	if err != nil {
+		return actualLabels
+	}
+	for _, label := range allLabels {
+		actualLabels[*label.Name] = *label
+	}
+
+	for _, label := range desiredLabels {
+		foundLabel, ok := actualLabels[*label.Name]
+		if ok {
+			if *foundLabel.Description != *label.Description {
+				_, _, err = g.client.Issues.EditLabel(ctx, os.Getenv("GITHUB_REPOSITORY_OWNER"), getRepo(), *label.Name, &github.Label{
+					Name:        label.Name,
+					Description: label.Description,
+				})
+				if err != nil {
+					return actualLabels
+				}
+			}
+		} else {
+			_, _, err = g.client.Issues.CreateLabel(ctx, os.Getenv("GITHUB_REPOSITORY_OWNER"), getRepo(), &label)
+			if err != nil {
+				return actualLabels
+			}
+		}
+		actualLabels[*label.Name] = label
+	}
+	return actualLabels
+}
+
+func (g *Git) setPRLabels(background context.Context, owner string, repo string, issueNumber int, labelTypes map[string]github.Label, actualLabels, desiredLabels []*github.Label) {
+	shouldRemove := []string{}
+	shouldAdd := []string{}
+	for _, label := range actualLabels {
+		foundInDesired := false
+		for _, desired := range desiredLabels {
+			if label.GetName() == desired.GetName() {
+				foundInDesired = true
+				break
+			}
+			if _, ok := labelTypes[label.GetName()]; !ok {
+				foundInDesired = true
+				continue
+			}
+			break
+		}
+
+		if _, ok := versionbumps.GetBumpTypeLabels()[versioning.BumpType(label.GetName())]; ok && !foundInDesired {
+			shouldRemove = append(shouldRemove, label.GetName())
+		}
+	}
+	for _, desired := range desiredLabels {
+		foundInActual := false
+		for _, label := range actualLabels {
+			if label.GetName() == desired.GetName() {
+				foundInActual = true
+				break
+			}
+		}
+		if !foundInActual {
+			shouldAdd = append(shouldAdd, desired.GetName())
+		}
+	}
+	if len(shouldAdd) > 0 {
+		_, _, err := g.client.Issues.AddLabelsToIssue(background, owner, repo, issueNumber, shouldAdd)
+		if err != nil {
+			logging.Info("failed to add labels %v: %s", shouldAdd, err.Error())
+		}
+	}
+	if len(shouldRemove) > 0 {
+		for _, label := range shouldRemove {
+			_, err := g.client.Issues.RemoveLabelForIssue(background, owner, repo, issueNumber, label)
+			if err != nil {
+				logging.Info("failed to remove labels %s: %s", label, err.Error())
+			}
+		}
+	}
+}
+
+func PRVersionMetadata(m *versioning.MergedVersionReport, labelTypes map[string]github.Label) (string, *versioning.BumpType, []*github.Label) {
+	var labelBumpTypeAdded *versioning.BumpType
+	if m == nil {
+		return "", labelBumpTypeAdded, []*github.Label{}
+	}
+	labels := []*github.Label{}
+	skipBumpType := false
+	skipVersionNumber := false
+	singleBumpType := ""
+	singleNewVersion := ""
+	for _, report := range m.Reports {
+		if len(report.BumpType) > 0 && report.BumpType != versioning.BumpNone && report.BumpType != versioning.BumpCustom {
+			if len(singleBumpType) > 0 {
+				skipBumpType = true
+			}
+			singleBumpType = string(report.BumpType)
+		}
+		if len(report.NewVersion) > 0 {
+			if len(singleNewVersion) > 0 {
+				skipVersionNumber = true
+			}
+			singleNewVersion = report.NewVersion
+		}
+	}
+	var builder []string
+	if !skipVersionNumber {
+		builder = append(builder, singleNewVersion)
+	}
+	if !skipBumpType {
+		if matched, ok := labelTypes[singleBumpType]; ok {
+			labels = append(labels, &matched)
+			bumpType := versioning.BumpType(singleBumpType)
+			labelBumpTypeAdded = &bumpType
+		}
+	}
+	// Add an extra " " at front
+	if len(builder) > 0 {
+		builder = append([]string{""}, builder...)
+	}
+	return strings.Join(builder, " "), labelBumpTypeAdded, labels
+}

--- a/internal/git/labels.go
+++ b/internal/git/labels.go
@@ -72,6 +72,7 @@ func (g *Git) setPRLabels(background context.Context, owner string, repo string,
 			break
 		}
 
+		// We shouldn't delete labels that aren't managed by us
 		if _, ok := versionbumps.GetBumpTypeLabels()[versioning.BumpType(label.GetName())]; ok && !foundInDesired {
 			shouldRemove = append(shouldRemove, label.GetName())
 		}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -73,6 +73,7 @@ func Run(g Git, pr *github.PullRequest, wf *workflow.Workflow) (*RunResult, map[
 
 	var manualVersioningBump *versioning.BumpType
 	if versionBump := versionbumps.GetLabelBasedVersionBump(pr); versionBump != "" && versionBump != versioning.BumpNone {
+		fmt.Println("ATTACHING MANUAL VERSION")
 		manualVersioningBump = &versionBump
 	}
 

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -73,7 +73,7 @@ func Run(g Git, pr *github.PullRequest, wf *workflow.Workflow) (*RunResult, map[
 
 	var manualVersioningBump *versioning.BumpType
 	if versionBump := versionbumps.GetLabelBasedVersionBump(pr); versionBump != "" && versionBump != versioning.BumpNone {
-		fmt.Println("ATTACHING MANUAL VERSION")
+		fmt.Println("Using label based version bump: ", versionBump)
 		manualVersioningBump = &versionBump
 	}
 

--- a/internal/versionbumps/versionBumps.go
+++ b/internal/versionbumps/versionBumps.go
@@ -1,0 +1,116 @@
+package versionbumps
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/google/go-github/v63/github"
+	"github.com/speakeasy-api/versioning-reports/versioning"
+	"golang.org/x/exp/slices"
+)
+
+type BumpMethod string
+
+// Enum values for BumpMethod
+const (
+	BumpMethodManual    BumpMethod = "Manual"
+	BumpMethodAutomated BumpMethod = "Automated"
+)
+
+var bumpTypeLabels = map[versioning.BumpType]string{
+	versioning.BumpMajor:      "Major version bump",
+	versioning.BumpMinor:      "Minor version bump",
+	versioning.BumpPatch:      "Patch version bump",
+	versioning.BumpGraduate:   "Graduate prerelease to stable",
+	versioning.BumpPrerelease: "Bump by a prerelease version",
+}
+
+type VersioningInfo struct {
+	ManualBump    bool
+	VersionReport *versioning.MergedVersionReport
+}
+
+func GetBumpTypeLabels() map[versioning.BumpType]string {
+	return bumpTypeLabels
+}
+
+func GetLabelBasedVersionBump(pr *github.PullRequest) versioning.BumpType {
+	if pr == nil {
+		return versioning.BumpNone
+	}
+
+	var bumpLabels []versioning.BumpType
+	for _, label := range pr.Labels {
+		if _, ok := bumpTypeLabels[versioning.BumpType(label.GetName())]; ok {
+			bumpLabels = append(bumpLabels, versioning.BumpType(label.GetName()))
+		}
+	}
+
+	if bumpType := stackRankBumpLabels(bumpLabels); bumpType != versioning.BumpNone {
+		currentPRBumpType, currentPRBumpMethod, err := parseBumpFromPRBody(pr.GetBody())
+		if err != nil {
+			fmt.Errorf("failed to parse bump type and mode from PR body: %w", err)
+			return versioning.BumpNone
+		}
+
+		// rules for explicit label versioning
+		// if the current Bump Type != label based versioning Bump we will use the label based versioning Bump
+		// if the current Bump Type == label based versioning Bump  and that was manually set we will stick to it
+		if currentPRBumpType != bumpType || currentPRBumpMethod == BumpMethodManual {
+			return bumpType
+		}
+	}
+
+	return versioning.BumpNone
+}
+
+func ManualBumpWasUsed(bumpType *versioning.BumpType, versionReport *versioning.MergedVersionReport) bool {
+	if bumpType == nil || versionReport == nil {
+		return false
+	}
+
+	for _, report := range versionReport.Reports {
+		if report.BumpType == *bumpType {
+			return true
+		}
+	}
+
+	return false
+}
+
+func parseBumpFromPRBody(prBody string) (versioning.BumpType, BumpMethod, error) {
+	re := regexp.MustCompile(`Version Bump Type:\s*(\w+)\s*\[(Manual|Automated)\]`)
+	matches := re.FindStringSubmatch(prBody)
+
+	// Check if the expected parts were found
+	if len(matches) != 3 {
+		return "", "", fmt.Errorf("failed to parse bump type and mode from PR body")
+	}
+
+	// Extract bump type and mode
+	bumpType := matches[1]
+	mode := matches[2]
+	if _, ok := bumpTypeLabels[versioning.BumpType(bumpType)]; !ok {
+		return "", "", fmt.Errorf("invalid bump type: %s", bumpType)
+	}
+
+	return versioning.BumpType(bumpType), BumpMethod(mode), nil
+}
+
+func stackRankBumpLabels(bumpLabels []versioning.BumpType) versioning.BumpType {
+	// Priority order from highest to lowest
+	priorityOrder := []versioning.BumpType{
+		versioning.BumpGraduate,
+		versioning.BumpMajor,
+		versioning.BumpMinor,
+		versioning.BumpPatch,
+	}
+
+	for _, priority := range priorityOrder {
+		if slices.Contains(bumpLabels, priority) {
+			return priority
+		}
+	}
+
+	return versioning.BumpNone
+}

--- a/internal/versionbumps/versionBumps.go
+++ b/internal/versionbumps/versionBumps.go
@@ -35,6 +35,8 @@ func GetBumpTypeLabels() map[versioning.BumpType]string {
 }
 
 func GetLabelBasedVersionBump(pr *github.PullRequest) versioning.BumpType {
+	fmt.Println("CHECKING FOR VERSION BUMPS")
+	fmt.Println(pr.Labels)
 	if pr == nil {
 		return versioning.BumpNone
 	}
@@ -46,8 +48,12 @@ func GetLabelBasedVersionBump(pr *github.PullRequest) versioning.BumpType {
 		}
 	}
 
+	fmt.Println(bumpTypeLabels)
+
 	if bumpType := stackRankBumpLabels(bumpLabels); bumpType != versioning.BumpNone {
 		currentPRBumpType, currentPRBumpMethod, err := parseBumpFromPRBody(pr.GetBody())
+		fmt.Println(currentPRBumpType)
+		fmt.Println(currentPRBumpMethod)
 		if err != nil {
 			fmt.Errorf("failed to parse bump type and mode from PR body: %w", err)
 			return versioning.BumpNone
@@ -57,6 +63,7 @@ func GetLabelBasedVersionBump(pr *github.PullRequest) versioning.BumpType {
 		// if the current Bump Type != label based versioning Bump we will use the label based versioning Bump
 		// if the current Bump Type == label based versioning Bump  and that was manually set we will stick to it
 		if currentPRBumpType != bumpType || currentPRBumpMethod == BumpMethodManual {
+			fmt.Println("WE HIT A CHANGE")
 			return bumpType
 		}
 	}

--- a/internal/versionbumps/versionBumps.go
+++ b/internal/versionbumps/versionBumps.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/google/go-github/v63/github"
+	"github.com/speakeasy-api/sdk-generation-action/internal/environment"
 	"github.com/speakeasy-api/versioning-reports/versioning"
 	"golang.org/x/exp/slices"
 )
@@ -65,6 +66,11 @@ func GetLabelBasedVersionBump(pr *github.PullRequest) versioning.BumpType {
 }
 
 func ManualBumpWasUsed(bumpType *versioning.BumpType, versionReport *versioning.MergedVersionReport) bool {
+	// the combination of setting a manual version and a force is considered a manual bump
+	if environment.SetVersion() != "" && environment.ForceGeneration() {
+		return true
+	}
+
 	if bumpType == nil || versionReport == nil {
 		return false
 	}

--- a/internal/versionbumps/versionBumps.go
+++ b/internal/versionbumps/versionBumps.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 
 	"github.com/google/go-github/v63/github"
-	"github.com/speakeasy-api/sdk-generation-action/internal/environment"
 	"github.com/speakeasy-api/versioning-reports/versioning"
 	"golang.org/x/exp/slices"
 )
@@ -66,11 +65,6 @@ func GetLabelBasedVersionBump(pr *github.PullRequest) versioning.BumpType {
 }
 
 func ManualBumpWasUsed(bumpType *versioning.BumpType, versionReport *versioning.MergedVersionReport) bool {
-	// the combination of setting a manual version and a force is considered a manual bump
-	if environment.SetVersion() != "" && environment.ForceGeneration() {
-		return true
-	}
-
 	if bumpType == nil || versionReport == nil {
 		return false
 	}

--- a/internal/versionbumps/versionBumps.go
+++ b/internal/versionbumps/versionBumps.go
@@ -13,8 +13,8 @@ type BumpMethod string
 
 // Enum values for BumpMethod
 const (
-	BumpMethodManual    BumpMethod = "Manual"
-	BumpMethodAutomated BumpMethod = "Automated"
+	BumpMethodManual    BumpMethod = "👤"
+	BumpMethodAutomated BumpMethod = "🤖"
 )
 
 var bumpTypeLabels = map[versioning.BumpType]string{
@@ -87,7 +87,7 @@ func ManualBumpWasUsed(bumpType *versioning.BumpType, versionReport *versioning.
 
 // We get the recorded BumpType and BumpMethod out of the PR body
 func parseBumpFromPRBody(prBody string) (versioning.BumpType, BumpMethod, error) {
-	re := regexp.MustCompile(`Version Bump Type:\s*(\w+)\s*\[(Manual|Automated)\]`)
+	re := regexp.MustCompile(`Version Bump Type:\s*\[(\w+)]\s*-\s*(👤|🤖)`)
 	matches := re.FindStringSubmatch(prBody)
 
 	// Check if the expected parts were found

--- a/internal/versionbumps/versionBumps.go
+++ b/internal/versionbumps/versionBumps.go
@@ -80,6 +80,7 @@ func ManualBumpWasUsed(bumpType *versioning.BumpType, versionReport *versioning.
 
 // We get the recorded BumpType and BumpMethod out of the PR body
 func parseBumpFromPRBody(prBody string) (versioning.BumpType, BumpMethod, error) {
+	// be very careful if changing this regex, it is critical
 	re := regexp.MustCompile(`Version Bump Type:\s*\[(\w+)]\s*-\s*(👤|🤖)`)
 	matches := re.FindStringSubmatch(prBody)
 

--- a/internal/versionbumps/versionBumps.go
+++ b/internal/versionbumps/versionBumps.go
@@ -35,8 +35,6 @@ func GetBumpTypeLabels() map[versioning.BumpType]string {
 }
 
 func GetLabelBasedVersionBump(pr *github.PullRequest) versioning.BumpType {
-	fmt.Println("CHECKING FOR VERSION BUMPS")
-	fmt.Println(pr.Labels)
 	if pr == nil {
 		return versioning.BumpNone
 	}
@@ -48,12 +46,8 @@ func GetLabelBasedVersionBump(pr *github.PullRequest) versioning.BumpType {
 		}
 	}
 
-	fmt.Println(bumpTypeLabels)
-
 	if bumpType := stackRankBumpLabels(bumpLabels); bumpType != versioning.BumpNone {
 		currentPRBumpType, currentPRBumpMethod, err := parseBumpFromPRBody(pr.GetBody())
-		fmt.Println(currentPRBumpType)
-		fmt.Println(currentPRBumpMethod)
 		if err != nil {
 			fmt.Errorf("failed to parse bump type and mode from PR body: %w", err)
 			return versioning.BumpNone
@@ -63,7 +57,6 @@ func GetLabelBasedVersionBump(pr *github.PullRequest) versioning.BumpType {
 		// if the current Bump Type != label based versioning Bump we will use the label based versioning Bump
 		// if the current Bump Type == label based versioning Bump  and that was manually set we will stick to it
 		if currentPRBumpType != bumpType || currentPRBumpMethod == BumpMethodManual {
-			fmt.Println("WE HIT A CHANGE")
 			return bumpType
 		}
 	}

--- a/internal/versionbumps/versionBumps.go
+++ b/internal/versionbumps/versionBumps.go
@@ -78,6 +78,7 @@ func ManualBumpWasUsed(bumpType *versioning.BumpType, versionReport *versioning.
 	return false
 }
 
+// We get the recorded BumpType and BumpMethod out of the PR body
 func parseBumpFromPRBody(prBody string) (versioning.BumpType, BumpMethod, error) {
 	re := regexp.MustCompile(`Version Bump Type:\s*(\w+)\s*\[(Manual|Automated)\]`)
 	matches := re.FindStringSubmatch(prBody)
@@ -97,6 +98,7 @@ func parseBumpFromPRBody(prBody string) (versioning.BumpType, BumpMethod, error)
 	return versioning.BumpType(bumpType), BumpMethod(mode), nil
 }
 
+// If someone happens to have multiple version labels applied we have a specific priority rankings for determining bump type
 func stackRankBumpLabels(bumpLabels []versioning.BumpType) versioning.BumpType {
 	// Priority order from highest to lowest
 	priorityOrder := []versioning.BumpType{


### PR DESCRIPTION
Discussed a while with @ThomasRooney quite a few different things we need to think about for this feature

- Because we add version labels to PRs if someone is triggering generation off of label added this could lead to duplicate generations potentially even an infinite loop. This is taken care of by PR body record being different from the version label applied
- If someone manually sets a version bump label and that does not align with what is in the PR body we will generate with that version bump label.
- If we set the bump type label. We don't want to stick on that bump type for ever. The SDK could evolve if the PR is left open for a long time. This is why we will utilize the [Automated] marking in PR body. 
- If someone manually sets a version bump label we will allow them to stay on that bump type in perpetuity using the [Manual] marking

This PR should address all those things


Note: I still need to add the infinite trigger short-circuit to workflow-executor. I will add that in this PR