### PR TITLE
feat: Support skip_testing input to explicitly skip target testing

### DIFF
--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -78,6 +78,11 @@ on:
         description: "Version of pnpm to install. Not recommended for use without consulting Speakeasy support."
         required: false
         type: string
+      skip_testing:
+        description: "Set to true to explicitly skip Speakeasy workflow target testing after generation, even when enabled in the Speakeasy workflow configuration. This is useful for running workflow testing as a separate GitHub Actions workflow without affecting/blocking generation."
+        default: false
+        required: false
+        type: boolean
     secrets:
       github_access_token:
         description: A GitHub access token with write access to the repo

--- a/action.yml
+++ b/action.yml
@@ -94,6 +94,10 @@ inputs:
   pnpm_version:
     description: "Version of pnpm to install. Not recommended for use without consulting Speakeasy support."
     required: false
+  skip_testing:
+    description: "Set to true to explicitly skip Speakeasy workflow target testing after generation, even when enabled in the Speakeasy workflow configuration. This is useful for running workflow testing as a separate GitHub Actions workflow without affecting/blocking generation."
+    default: "false"
+    required: false
 outputs:
   publish_python:
     description: "Whether the Python SDK will be published to PyPi"

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -61,6 +61,10 @@ func Run(sourcesOnly bool, installationURLs map[string]string, repoURL string, r
 		args = append(args, "--set-version", environment.SetVersion())
 	}
 
+	if environment.SkipTesting() {
+		args = append(args, "--skip-testing")
+	}
+
 	if environment.ForceGeneration() {
 		fmt.Println("\nforce input enabled - setting SPEAKEASY_FORCE_GENERATION=true")
 		os.Setenv("SPEAKEASY_FORCE_GENERATION", "true")

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -97,6 +97,11 @@ func RegistryTags() string {
 	return os.Getenv("INPUT_REGISTRY_TAGS")
 }
 
+// Enabled if the INPUT_SKIP_TESTING environment variable is set to "true".
+func SkipTesting() bool {
+	return os.Getenv("INPUT_SKIP_TESTING") == "true"
+}
+
 func SpecifiedTarget() string {
 	return os.Getenv("INPUT_TARGET")
 }


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/GEN-780/feature-sdk-generation-action-skip-target-testing-input

Set to true to explicitly skip Speakeasy workflow target testing after generation, even when enabled in the Speakeasy workflow configuration. This is useful for running workflow testing as a separate GitHub Actions workflow without affecting/blocking generation. It can also be used to workaround potential testing bugs where the generation should still be preserved.