### PR TITLE
chore: downgrade default runs-on

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       runs-on:
         description: The GitHub Action Runner
-        default: ubuntu-latest
+        default: ubuntu-22.04
         required: false
         type: string
       speakeasy_server_url:

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       runs-on:
         description: The GitHub Action Runner
-        default: ubuntu-latest
+        default: ubuntu-22.04
         required: false
         type: string
       speakeasy_version:


### PR DESCRIPTION
Downgrade the default github runner image to 22.04 due to observed failings of .NET publishing in the 24.04 rollout.