### PR TITLE
feat: Support poetry_version input to specify Poetry tool version

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: "5.x"
+      poetry_version:
+        description: "The version of poetry to use"
+        required: false
+        type: string
       target:
         description: "The specific target to publish"
         required: false
@@ -154,11 +158,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install poetry
         run: |
-          curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.8.3 python3 -
+          curl -sSL https://install.python-poetry.org | python3 -
           poetry --version
+        env:
+          POETRY_VERSION: ${{ inputs.poetry_version }}
       - name: Check for publish.sh
         id: check-publish
         run: |

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -78,6 +78,10 @@ on:
         description: "Version of pnpm to install. Not recommended for use without consulting Speakeasy support."
         required: false
         type: string
+      poetry_version:
+        description: "Version of poetry to install. Not recommended for use without consulting Speakeasy support."
+        required: false
+        type: string
     secrets:
       github_access_token:
         description: A GitHub access token with write access to the repo
@@ -208,6 +212,7 @@ jobs:
           set_version: ${{ inputs.set_version }}
           cli_environment_variables: ${{ inputs.environment }}
           pnpm_version: ${{ inputs.pnpm_version }}
+          poetry_version: ${{ inputs.poetry_version }}
       - uses: ravsamhq/notify-slack-action@v2
         if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true' && env.SLACK_WEBHOOK_URL != '' }}
         with:
@@ -257,11 +262,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install poetry
         run: |
-          curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.8.3 python3 -
+          curl -sSL https://install.python-poetry.org | python3 -
           poetry --version
+        env:
+          POETRY_VERSION: ${{ inputs.poetry_version }}
       - name: Check for publish.sh
         id: check-publish
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,7 @@ RUN apk add git
 RUN apk add --update --no-cache nodejs npm
 
 ### Install Python
-RUN apk add --update --no-cache python3 py3-pip python3-dev
-
-### Install Poetry and validate
-RUN apk add --update --no-cache poetry
-RUN poetry --version
+RUN apk add --update --no-cache python3 py3-pip python3-dev pipx
 
 ### Install Java
 RUN apk add --update --no-cache openjdk11 gradle

--- a/action.yml
+++ b/action.yml
@@ -94,6 +94,9 @@ inputs:
   pnpm_version:
     description: "Version of pnpm to install. Not recommended for use without consulting Speakeasy support."
     required: false
+  poetry_version:
+    description: "Version of poetry to install. Not recommended for use without consulting Speakeasy support."
+    required: false
 outputs:
   publish_python:
     description: "Whether the Python SDK will be published to PyPi"
@@ -199,3 +202,4 @@ runs:
     - ${{ inputs.set_version }}
     - ${{ inputs.cli_environment_variables }}
     - ${{ inputs.pnpm_version }}
+    - ${{ inputs.poetry_version }}

--- a/internal/actions/setup_environment.go
+++ b/internal/actions/setup_environment.go
@@ -13,6 +13,10 @@ import (
 // publishing, then an input (pnpm_version in this case) should be set to a
 // non-empty value and this logic will install the dependency.
 func SetupEnvironment() error {
+	if err := installPoetry(); err != nil {
+		return err
+	}
+
 	if pnpmVersion := environment.GetPnpmVersion(); pnpmVersion != "" {
 		pnpmPackageSpec := "pnpm@" + pnpmVersion
 		cmd := exec.Command("npm", "install", "-g", pnpmPackageSpec)
@@ -20,6 +24,24 @@ func SetupEnvironment() error {
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("error installing %s: %w", pnpmPackageSpec, err)
 		}
+	}
+
+	return nil
+}
+
+// Installs poetry using pipx. If the INPUT_POETRY_VERSION environment variable
+// is set, it will install that version.
+func installPoetry() error {
+	poetrySpec := "poetry"
+
+	if poetryVersion := environment.GetPoetryVersion(); poetryVersion != "" {
+		poetrySpec = "poetry==" + poetryVersion
+	}
+
+	cmd := exec.Command("pipx", "install", poetrySpec)
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error installing poetry: %w", err)
 	}
 
 	return nil

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -213,6 +213,10 @@ func GetOpenAPIDocAuthToken() string {
 	return os.Getenv("INPUT_OPENAPI_DOC_AUTH_TOKEN")
 }
 
+func GetPoetryVersion() string {
+	return os.Getenv("INPUT_POETRY_VERSION")
+}
+
 func GetPnpmVersion() string {
 	return os.Getenv("INPUT_PNPM_VERSION")
 }


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/GEN-877/tech-debt-python-poetry-20

This change adds a `poetry_version` input to each of the workflows to specify the Poetry tool version to install and use. By default, the latest (2.0.0 as of this change) is installed, but this is being added as a compatibility layer for calling GitHub Actions workflows that pin the Speakeasy CLI to an older version, which require an older Poetry version before the major version update such as 1.8.3.

This change also bumps Python from 3.8 (EOL since October 2024) to 3.9 (required for Poetry 2.0.0) for publishing workflows.