### PR TITLE
fix: Remove unsupported openssl1.1-compat and .NET 5 (for Unity) from Docker image and add CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,15 +20,21 @@ jobs:
       id-token: "write"
       actions: "read"
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: ^1.21
+          go-version-file: "go.mod"
       - name: Configure git for private modules
         env:
           GIT_AUTH_TOKEN: ${{ secrets.BOT_REPO_TOKEN }}
         run: git config --global url."https://speakeasybot:${GIT_AUTH_TOKEN}@github.com".insteadOf "https://github.com"
-      - name: Check out code
-        uses: actions/checkout@v3
       - name: Test
         run: go test -v ./...
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0
+        with:
+          push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ RUN go build -o /action
 FROM golang:1.23-alpine3.20
 
 RUN apk update
-RUN apk add git
+
+### Install common tools
+RUN apk add --update --no-cache bash curl git
 
 ### Install Node / NPM
 RUN apk add --update --no-cache nodejs npm
@@ -35,12 +37,6 @@ RUN apk add --update --no-cache build-base ruby ruby-bundler ruby-dev
 ### Install .NET6.0
 ENV DOTNET_ROOT=/usr/lib/dotnet
 RUN apk add --update --no-cache dotnet6-sdk
-
-### Install .NET5.0
-RUN apk add --update --no-cache curl bash
-# openssl1.1-compat is gradually getting removed from package managers..
-RUN apk add --update --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing openssl1.1-compat
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -Channel 5.0 -InstallDir ${DOTNET_ROOT}
 
 ### Install .NET8.0
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -Channel 8.0 -InstallDir ${DOTNET_ROOT}


### PR DESCRIPTION
Reference: https://speakeasyapi.slack.com/archives/C06AT209C5A/p1736455295374799?thread_ts=1736445206.094809&cid=C06AT209C5A