### PR TITLE
fix: Ensure pipx install is global

### DIFF
--- a/internal/actions/setup_environment.go
+++ b/internal/actions/setup_environment.go
@@ -38,7 +38,7 @@ func installPoetry() error {
 		poetrySpec = "poetry==" + poetryVersion
 	}
 
-	cmd := exec.Command("pipx", "install", poetrySpec)
+	cmd := exec.Command("pipx", "install", "--global", poetrySpec)
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error installing poetry: %w", err)


### PR DESCRIPTION
Otherwise, `pipx install` binaries are not on the PATH for generator commands.