### PR TITLE
fix: add php session extension

### DIFF
--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -200,7 +200,7 @@ jobs:
       - id: run-workflow
         name: Run Generation Workflow
         if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true' }}
-        uses: speakeasy-api/sdk-generation-action@v15
+        uses: speakeasy-api/sdk-generation-action@v15.37.0
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}
@@ -231,7 +231,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       - id: log-result
         name: Log Generation Output
-        uses: speakeasy-api/sdk-generation-action@v15
+        uses: speakeasy-api/sdk-generation-action@v15.37.0
         if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true'}}
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,15 +44,25 @@ RUN dotnet --list-sdks
 
 ### Install PHP and Composer
 #### Source: https://github.com/geshan/docker-php-composer-alpine/blob/master/Dockerfile
-RUN apk --update --no-cache add wget \
-		     curl \
-		     git \
-		     php82 \
-         php-ctype php-dom php-json php-mbstring php-phar php-tokenizer php-xml php-xmlwriter \
-		     php-curl \
-		     php-openssl \
-		     php-iconv \
-		    --repository http://nl.alpinelinux.org/alpine/edge/testing/
+RUN apk --update --no-cache add \
+	wget \
+	curl \
+	git \
+	php83 \
+	php83-ctype \
+	php83-dom \
+	php83-json \
+	php83-mbstring \
+	php83-phar \
+	php83-tokenizer \
+	php83-xml \
+	php83-xmlwriter \
+	php83-curl \
+	php83-openssl \
+	php83-iconv \
+	php83-session \
+	--repository http://nl.alpinelinux.org/alpine/edge/testing/
+
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 RUN mkdir -p /var/www

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN apk --update --no-cache add \
 	php83-openssl \
 	php83-iconv \
 	php83-session \
+	php83-fileinfo \
 	--repository http://nl.alpinelinux.org/alpine/edge/testing/
 
 

--- a/action.yml
+++ b/action.yml
@@ -176,7 +176,7 @@ outputs:
     description: "The directory the SDK target was generated to"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15"
+  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.37.0"
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}


### PR DESCRIPTION
@ryan-timothy-albert 



Here's the output from docker build:

```
(1/19) Installing php83-common (8.3.15-r0)
(2/19) Installing php83-ctype (8.3.15-r0)
(3/19) Installing php83-curl (8.3.15-r0)
(4/19) Installing libxml2 (2.12.7-r0)
(5/19) Installing php83-dom (8.3.15-r0)
(6/19) Installing php83-iconv (8.3.15-r0)
(7/19) Installing oniguruma (6.9.9-r0)
(8/19) Installing php83-mbstring (8.3.15-r0)
(9/19) Installing php83-openssl (8.3.15-r0)
(10/19) Installing argon2-libs (20190702-r5)
(11/19) Installing libedit (20240517.3.1-r0)
(12/19) Installing php83 (8.3.15-r0)
(13/19) Installing php83-phar (8.3.15-r0)
(14/19) Installing php83-tokenizer (8.3.15-r0)
(15/19) Installing php83-xml (8.3.15-r0)
(16/19) Installing php83-xmlwriter (8.3.15-r0)
(17/19) Installing php82-common (8.2.27-r0)
(18/19) Installing php82 (8.2.27-r0)
(19/19) Installing wget (1.24.5-r0)
```

I guess that the `php` binary must be pointing at `php8.3` despite `php8.2` being installed.

Adding a `RUN php --version` to the docker file seems to confirm this:

`Step 22/30 : RUN php --version
 ---> Running in b0689b6e60bc
PHP 8.3.15 (cli) (built: Dec 20 2024 20:11:30) (NTS)
`

So, I'm leaning into 8.3 and I added the `php83-session` extension that was throwing the error against polar.

I don't understand what's going on, or why that error is only throwing when additionalDependencies are set, but this _should_ fix that error at least.