### PR TITLE
feat: Add ability to sign commits when flag is enabled

### DIFF
--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -33,6 +33,10 @@ on:
         default: "false"
         required: false
         type: string
+      signed_commits:
+        required:false
+        description: "Sign commits with GPG key"
+        type: boolean
       speakeasy_server_url:
         required: false
         description: "Internal use only"

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -35,7 +35,7 @@ on:
         type: string
       signed_commits:
         required: false
-        description: "Sign commits with GPG key"
+        description: "This will set commits to be signed and and verified"
         type: boolean
       speakeasy_server_url:
         required: false

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -210,6 +210,7 @@ jobs:
           github_access_token: ${{ secrets.github_access_token }}
           mode: ${{ inputs.mode }}
           force: ${{ inputs.force }}
+          signed_commits: ${{ inputs.signed_commits }}
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
           output_tests: ${{ inputs.output_tests }}
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -34,7 +34,7 @@ on:
         required: false
         type: string
       signed_commits:
-        required:false
+        required: false
         description: "Sign commits with GPG key"
         type: boolean
       speakeasy_server_url:

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -204,7 +204,7 @@ jobs:
       - id: run-workflow
         name: Run Generation Workflow
         if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true' }}
-        uses: speakeasy-api/sdk-generation-action@v15.38.1
+        uses: speakeasy-api/sdk-generation-action@v15
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -200,7 +200,7 @@ jobs:
       - id: run-workflow
         name: Run Generation Workflow
         if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true' }}
-        uses: speakeasy-api/sdk-generation-action@v15
+        uses: speakeasy-api/sdk-generation-action@v15.38.0
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -204,7 +204,7 @@ jobs:
       - id: run-workflow
         name: Run Generation Workflow
         if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true' }}
-        uses: speakeasy-api/sdk-generation-action@v15.38.0
+        uses: speakeasy-api/sdk-generation-action@v15.38.1
         with:
           speakeasy_version: ${{ inputs.speakeasy_version }}
           github_access_token: ${{ secrets.github_access_token }}

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Force the SDK to be regenerated"
     default: "false"
     required: false
+  signed_commits:
+    description: "Sign commits with GPG"
+    default: "false"
+    required: false
   sources:
     description: "The sources to tag (comma or newline separated)"
     required: false
@@ -191,6 +195,7 @@ runs:
     - ${{ inputs.action }}
     - ${{ inputs.branch_name }}
     - ${{ inputs.cli_output }}
+    - ${{ inputs.signed_commits }}
     - ${{ inputs.previous_gen_version }}
     - ${{ inputs.openapi_doc_output }}
     - ${{ inputs.output_tests }}

--- a/action.yml
+++ b/action.yml
@@ -180,7 +180,7 @@ outputs:
     description: "The directory the SDK target was generated to"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.38.1"
+  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15"
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}

--- a/action.yml
+++ b/action.yml
@@ -176,7 +176,7 @@ outputs:
     description: "The directory the SDK target was generated to"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15"
+  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.38.0"
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}

--- a/action.yml
+++ b/action.yml
@@ -180,7 +180,7 @@ outputs:
     description: "The directory the SDK target was generated to"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.38.0"
+  image: "docker://ghcr.io/speakeasy-api/sdk-generation-action:v15.38.1"
   env:
     SPEAKEASY_API_KEY: ${{ inputs.speakeasy_api_key }}
     SPEAKEASY_SERVER_URL: ${{ inputs.speakeasy_server_url }}

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -238,6 +238,10 @@ func GetWorkflowEventLabelName() string {
 	return os.Getenv("GITHUB_EVENT_LABEL_NAME")
 }
 
+func GetSignedCommits() bool {
+	return os.Getenv("INPUT_SIGNED_COMMITS") == "true"
+}
+
 func GetBranchName() string {
 	return os.Getenv("INPUT_BRANCH_NAME")
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -449,10 +449,6 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 	commitResult, _, err := g.client.Git.CreateCommit(context.Background(), owner, repo, &github.Commit{
 		Message: github.String(commitMessage),
 		Tree:    &github.Tree{SHA: tree.SHA},
-		Author: &github.CommitAuthor{
-			Name:  github.String("speakeasybot"),
-			Email: github.String("bot@speakeasyapi.dev"),
-		},
 		Parents: []*github.Commit{parentCommit}}, &github.CreateCommitOptions{})
 	if err != nil {
 		return "", fmt.Errorf("error committing changes: %w", err)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -355,14 +355,13 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 	if g.repo == nil {
 		return "", fmt.Errorf("repo not cloned")
 	}
-
+	fmt.Println("Using Signed Commits")
 	// In test mode do not commit and push, just move forward
 	if environment.IsTestMode() {
 		return "", nil
 	}
 
 	_, githubRepoLocation := g.getRepoMetadata()
-
 	owner, repo := g.getOwnerAndRepo(githubRepoLocation)
 
 	branch, err := g.GetCurrentBranch()

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -505,7 +505,7 @@ func (g *Git) createAndPushTree(ref *github.Reference, sourceFiles git.Status) (
 
 	// Load each file into the tree.
 	for file, fileStatus := range sourceFiles {
-		if fileStatus.Staging != git.Unmodified && fileStatus.Staging != git.Untracked {
+		if fileStatus.Staging != git.Unmodified && fileStatus.Staging != git.Untracked && fileStatus.Staging != git.Deleted {
 			fmt.Println("Using new file path using working tree")
 			filePath := workingDirectory.Filesystem.Join(workingDirectory.Filesystem.Root(), file)
 			content, err := os.ReadFile(filePath)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -420,12 +420,13 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 	}
 
 	// Commit actual changes
-	commitResult, response, err := g.client.Git.CreateCommit(context.Background(), owner, repo, &github.Commit{
+	commitResult, _, err := g.client.Git.CreateCommit(context.Background(), owner, repo, &github.Commit{
 		Message: github.String(commitMessage),
 		Tree:    &github.Tree{SHA: tree.SHA},
 		Parents: []*github.Commit{parentCommit}}, &github.CreateCommitOptions{})
-	fmt.Println("response", response, commitResult)
-
+	if err != nil {
+		return "", fmt.Errorf("error committing changes: %w", err)
+	}
 	// Update reference
 	newRef := &github.Reference{
 		Ref:    github.String("refs/heads/" + branch),

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -370,7 +370,6 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 
 	logging.Info("Commit and pushing changes to git")
 
-	// Add local files and changes
 	if err := g.Add("."); err != nil {
 		return "", fmt.Errorf("error adding changes: %w", err)
 	}
@@ -407,15 +406,6 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 		}
 		return commitHash.String(), nil
 	}
-
-	fmt.Println("Using Signed Commits")
-
-	// Set git user name and email to speakeasy bot
-	cmd := exec.Command("git", "config", "--global", "user.name", "speakeasybot")
-	cmd.CombinedOutput()
-
-	cmd = exec.Command("git", "config", "--global", "user.email", "bot@speakeasyapi.dev")
-	cmd.CombinedOutput()
 
 	branch, err := g.GetCurrentBranch()
 	if err != nil {
@@ -459,6 +449,10 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 	commitResult, _, err := g.client.Git.CreateCommit(context.Background(), owner, repo, &github.Commit{
 		Message: github.String(commitMessage),
 		Tree:    &github.Tree{SHA: tree.SHA},
+		Author: &github.CommitAuthor{
+			Name:  github.String("speakeasybot"),
+			Email: github.String("bot@speakeasyapi.dev"),
+		},
 		Parents: []*github.Commit{parentCommit}}, &github.CreateCommitOptions{})
 	if err != nil {
 		return "", fmt.Errorf("error committing changes: %w", err)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -433,7 +433,7 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 	fmt.Println("commit", commit)
 
 	// Commit actual changes
-	commitResult, response, err := g.client.Git.CreateCommit(Resultcontext.Background(), owner, repo, &github.Commit{
+	commitResult, response, err := g.client.Git.CreateCommit(context.Background(), owner, repo, &github.Commit{
 		Message: github.String(commitMessage),
 		Tree:    &github.Tree{SHA: parentCommit.Tree.SHA},
 		Parents: []*github.Commit{parentCommit},

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -363,33 +363,26 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 
 	_, githubRepoLocation := g.getRepoMetadata()
 	owner, repo := g.getOwnerAndRepo(githubRepoLocation)
+	w, err := g.repo.Worktree()
+	if err != nil {
+		return "", fmt.Errorf("error getting working tree: %w", err)
+	}
 
 	branch, err := g.GetCurrentBranch()
 	if err != nil {
 		return "", fmt.Errorf("error getting current branch: %w", err)
 	}
 
-	// Get working tree locally
-	// localWorkingTree, err := g.repo.Worktree()
-	// if err != nil {
-	// 	return "", fmt.Errorf("error getting worktree: %w", err)
-	// }
-
 	// Add local files and changes
 	if err := g.Add("."); err != nil {
 		return "", fmt.Errorf("error adding changes: %w", err)
 	}
-	w, _ := g.repo.Worktree()
-	status, err := w.Status()
 
-	fmt.Println("status", status)
-	fmt.Println("Attempting to push changes")
-	// if err := g.repo.Push(&git.PushOptions{
-	// 	Auth: getGithubAuth(g.accessToken),
-	// }); err != nil {
-	// 	fmt.Errorf("error in CommitAndPush code: %w", err, branch)
-	// 	return "", pushErr(err)
-	// }
+	// Get status of changed files
+	status, err := w.Status()
+	if err != nil {
+		return "", fmt.Errorf("error getting status for branch: %w", err)
+	}
 
 	ref, _, err := g.client.Git.GetRef(context.Background(), owner, repo, "refs/heads/"+branch)
 	if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -390,12 +390,11 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 		return "", fmt.Errorf("error getting repo head commit: %w", err)
 	}
 
-	fmt.Println("head name", head.Name())
+	fmt.Println("branch name, head name", branch, head.Name())
 
 	// Get the last commit for the branch
 	//g.getRef(branch,)
-	// Get the last commit for the branch
-	ref, _, err := g.client.Git.GetRef(context.Background(), owner, repo, "refs/heads/"+branch)
+	ref, err := g.getRef(branch, "main")
 	if err != nil {
 		return "", fmt.Errorf("error getting reference: %w", err)
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -442,7 +442,7 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 			Email: github.String("bot@speakeasyapi.dev"),
 			Date:  &github.Timestamp{Time: time.Now()},
 		}}, &github.CreateCommitOptions{})
-	fmt.Println("response", response)
+	fmt.Println("response", response, commitResult)
 	return *commitResult.SHA, nil
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -411,8 +411,11 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 	fmt.Println("Using Signed Commits")
 
 	// Set git user name and email to speakeasy bot
-	exec.Command("git", "config", "--global", "user.name", "speakeasybot")
-	exec.Command("git", "config", "--global", "user.email", "bot@speakeasyapi.dev")
+	cmd := exec.Command("git", "config", "--global", "user.name", "speakeasybot")
+	cmd.CombinedOutput()
+
+	cmd = exec.Command("git", "config", "--global", "user.email", "bot@speakeasyapi.dev")
+	cmd.CombinedOutput()
 
 	branch, err := g.GetCurrentBranch()
 	if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -419,37 +419,11 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 		return "", fmt.Errorf("error getting parent commit: %w", err)
 	}
 
-	// headRef, err := g.repo.Head()
-	// if err != nil {
-	// 	return "", fmt.Errorf("error getting HEAD: %w", err)
-	// }
-
-	// commit, err := g.repo.CommitObject(headRef.Hash())
-	// if err != nil {
-	// 	return "", fmt.Errorf("error getting commit object: %w", err)
-	// }
-
-	// tree, err := commit.Tree()
-	// if err != nil {
-	// 	return "", fmt.Errorf("error getting tree object: %w", err)
-	// }
-
-	// push changes to origin using go-github and client
-
-	// Get tree SHA from localWorkingTree and go git
-
-	// fmt.Println("commit", commit)
-
 	// Commit actual changes
 	commitResult, response, err := g.client.Git.CreateCommit(context.Background(), owner, repo, &github.Commit{
 		Message: github.String(commitMessage),
 		Tree:    &github.Tree{SHA: tree.SHA},
-		Parents: []*github.Commit{parentCommit},
-		Author: &github.CommitAuthor{
-			Name:  github.String("speakeasybot"),
-			Email: github.String("bot@speakeasyapi.dev"),
-			Date:  &github.Timestamp{Time: time.Now()},
-		}}, &github.CreateCommitOptions{})
+		Parents: []*github.Commit{parentCommit}}, &github.CreateCommitOptions{})
 	fmt.Println("response", response, commitResult)
 
 	// Update reference

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -365,7 +365,7 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 
 	w, err := g.repo.Worktree()
 	if err != nil {
-		return "", fmt.Errorf("error getting working tree: %w", err)
+		return "", fmt.Errorf("error getting worktree: %w", err)
 	}
 
 	logging.Info("Commit and pushing changes to git")
@@ -409,6 +409,10 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 	}
 
 	fmt.Println("Using Signed Commits")
+
+	// Set git user name and email to speakeasy bot
+	exec.Command("git", "config", "--global", "user.name", "speakeasybot")
+	exec.Command("git", "config", "--global", "user.email", "bot@speakeasyapi.dev")
 
 	branch, err := g.GetCurrentBranch()
 	if err != nil {
@@ -506,7 +510,6 @@ func (g *Git) createAndPushTree(ref *github.Reference, sourceFiles git.Status) (
 	// Load each file into the tree.
 	for file, fileStatus := range sourceFiles {
 		if fileStatus.Staging != git.Unmodified && fileStatus.Staging != git.Untracked && fileStatus.Staging != git.Deleted {
-			fmt.Println("Using new file path using working tree")
 			filePath := workingDirectory.Filesystem.Join(workingDirectory.Filesystem.Root(), file)
 			content, err := os.ReadFile(filePath)
 			if err != nil {

--- a/testing/pr-mode.env
+++ b/testing/pr-mode.env
@@ -4,3 +4,4 @@ INPUT_LANGUAGES="- go"
 GITHUB_REPOSITORY="speakeasy-api/sdk-generation-action-test-repo"
 INPUT_FORCE=true
 RUN_FINALIZE=true
+INPUT_SIGNED_COMMITS=true


### PR DESCRIPTION
When the `signed_commits` feature flag is enabled, commits will be commited using the GitHub API allowing our bot's committed to be `verified`.

### Before:
<img width="1722" alt="Screenshot 2025-02-05 at 2 36 21 PM" src="https://github.com/user-attachments/assets/eda143b6-f244-4821-a7d2-ce7d61cec97e" />

### After: 
<img width="1259" alt="Screenshot 2025-02-06 at 3 21 59 PM" src="https://github.com/user-attachments/assets/d2feceba-3ad7-4d37-890d-6f98f96ddbd0" />

