### PR TITLE
fix: Ensure poetry is installed in test mode

### DIFF
--- a/internal/actions/test.go
+++ b/internal/actions/test.go
@@ -30,6 +30,10 @@ func Test(ctx context.Context) error {
 		return err
 	}
 
+	if err := SetupEnvironment(); err != nil {
+		return fmt.Errorf("failed to setup environment: %w", err)
+	}
+
 	if _, err = cli.Download("latest", g); err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously was only installed in `run-workflow`/`""` action input. Without this, Python targets will receive errors such as:

```
WARN    cannot test target - Dependency Not Found - Install Poetry by following the instructions at https://python-poetry.org/docs/#installing-with-pipx.
  INFO    Shutting down mock server
  Error: error running tests for target xxx (python): dependency not found -- poetry: exec: "poetry": executable file not found in $PATH
  Failed to run with Speakeasy version 1.540.1: failed to run with version 1.540.1: exit status 1
```