### PR TITLE
feat: Support JSON string syntax for runs-on input

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -78,7 +78,7 @@ on:
 jobs:
   release:
     name: Create Github Release
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     outputs:
       publish_python: ${{ steps.release.outputs.publish_python }}
       publish_typescript: ${{ steps.release.outputs.publish_typescript }}
@@ -147,7 +147,7 @@ jobs:
   publish-pypi:
     if: ${{ needs.release.outputs.python_regenerated == 'true' && needs.release.outputs.publish_python == 'true' }}
     name: Publish Python SDK
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: release
     defaults:
       run:
@@ -230,7 +230,7 @@ jobs:
   publish-npm:
     if: ${{ needs.release.outputs.typescript_regenerated == 'true' && needs.release.outputs.publish_typescript == 'true' }}
     name: Publish Typescript SDK
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: release
     defaults:
       run:
@@ -327,7 +327,7 @@ jobs:
   publish-java:
     if: ${{ needs.release.outputs.java_regenerated == 'true' && needs.release.outputs.publish_java == 'true' }}
     name: Publish Java SDK
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: release
     defaults:
       run:
@@ -404,7 +404,7 @@ jobs:
   publish-packagist:
     if: ${{ needs.release.outputs.php_regenerated == 'true' && needs.release.outputs.publish_php == 'true' }}
     name: Publish PHP SDK
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: release
     defaults:
       run:
@@ -462,7 +462,7 @@ jobs:
   publish-nuget:
     if: ${{ needs.release.outputs.csharp_regenerated == 'true' && needs.release.outputs.publish_csharp == 'true' }}
     name: Publish C# SDK
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: release
     defaults:
       run:
@@ -519,7 +519,7 @@ jobs:
   publish-terraform:
     if: ${{ needs.release.outputs.terraform_regenerated == 'true' && needs.release.outputs.publish_terraform == 'true' }}
     name: Publish Terraform Provider
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: release
     steps:
       - name: Tune GitHub-hosted runner network
@@ -587,7 +587,7 @@ jobs:
   publish-gems:
     if: ${{ needs.release.outputs.ruby_regenerated == 'true' && needs.release.outputs.publish_ruby == 'true' }}
     name: Publish Ruby SDK
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: release
     defaults:
       run:

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -82,7 +82,7 @@ on:
 jobs:
   release:
     name: Create Github Release
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     outputs:
       publish_python: ${{ steps.release.outputs.publish_python }}
       publish_typescript: ${{ steps.release.outputs.publish_typescript }}
@@ -151,7 +151,7 @@ jobs:
   publish-pypi:
     if: ${{ needs.release.outputs.python_regenerated == 'true' && needs.release.outputs.publish_python == 'true' }}
     name: Publish Python SDK
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     needs: release
     defaults:
       run:
@@ -234,7 +234,7 @@ jobs:
   publish-npm:
     if: ${{ needs.release.outputs.typescript_regenerated == 'true' && needs.release.outputs.publish_typescript == 'true' }}
     name: Publish Typescript SDK
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     needs: release
     defaults:
       run:
@@ -331,7 +331,7 @@ jobs:
   publish-java:
     if: ${{ needs.release.outputs.java_regenerated == 'true' && needs.release.outputs.publish_java == 'true' }}
     name: Publish Java SDK
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     needs: release
     defaults:
       run:
@@ -408,7 +408,7 @@ jobs:
   publish-packagist:
     if: ${{ needs.release.outputs.php_regenerated == 'true' && needs.release.outputs.publish_php == 'true' }}
     name: Publish PHP SDK
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     needs: release
     defaults:
       run:
@@ -466,7 +466,7 @@ jobs:
   publish-nuget:
     if: ${{ needs.release.outputs.csharp_regenerated == 'true' && needs.release.outputs.publish_csharp == 'true' }}
     name: Publish C# SDK
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     needs: release
     defaults:
       run:
@@ -523,7 +523,7 @@ jobs:
   publish-terraform:
     if: ${{ needs.release.outputs.terraform_regenerated == 'true' && needs.release.outputs.publish_terraform == 'true' }}
     name: Publish Terraform Provider
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     needs: release
     steps:
       - name: Tune GitHub-hosted runner network
@@ -591,7 +591,7 @@ jobs:
   publish-gems:
     if: ${{ needs.release.outputs.ruby_regenerated == 'true' && needs.release.outputs.publish_ruby == 'true' }}
     name: Publish Ruby SDK
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     needs: release
     defaults:
       run:

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -4,7 +4,11 @@ on:
   workflow_call:
     inputs:
       runs-on:
-        description: The GitHub Action Runner
+        description: |-
+          Define the type of machine to run the job on. This can be a single string value or a JSON-encoded string value
+          to define a runs-on compatible array/object, such as '["one", "two"]'. Refer to the GitHub Actions
+          documentation at https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on
+          for more details about runs-on values.
         default: ubuntu-22.04
         required: false
         type: string

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -150,7 +150,7 @@ on:
 jobs:
   run-workflow:
     name: Generate Target
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     outputs:
       commit_hash: ${{ steps.run-workflow.outputs.commit_hash }}
       publish_python: ${{ steps.run-workflow.outputs.publish_python }}
@@ -266,7 +266,7 @@ jobs:
       needs.run-workflow.outputs.publish_python == 'true'
       && inputs.mode != 'pr' }}
     name: Publish Python SDK
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     needs: [run-workflow]
     defaults:
       run:
@@ -357,7 +357,7 @@ jobs:
       needs.run-workflow.outputs.publish_typescript == 'true'
       && inputs.mode != 'pr' }}
     name: Publish Typescript SDK
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     needs: [run-workflow]
     defaults:
       run:
@@ -427,7 +427,7 @@ jobs:
       needs.run-workflow.outputs.publish_java == 'true'
       && inputs.mode != 'pr' }}
     name: Publish Java SDK
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     needs: [run-workflow]
     defaults:
       run:
@@ -513,7 +513,7 @@ jobs:
       needs.run-workflow.outputs.publish_ruby == 'true'
       && inputs.mode != 'pr' }}
     name: Publish Ruby SDK
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     needs: [run-workflow]
     defaults:
       run:
@@ -588,7 +588,7 @@ jobs:
       needs.run-workflow.outputs.publish_csharp == 'true'
       && inputs.mode != 'pr' }}
     name: Publish C# SDK
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     needs: [run-workflow]
     defaults:
       run:
@@ -653,7 +653,7 @@ jobs:
       needs.run-workflow.outputs.publish_php == 'true'
       && inputs.mode != 'pr' }}
     name: Publish PHP SDK
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
     needs: [run-workflow]
     defaults:
       run:

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -146,7 +146,7 @@ on:
 jobs:
   run-workflow:
     name: Generate Target
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     outputs:
       commit_hash: ${{ steps.run-workflow.outputs.commit_hash }}
       publish_python: ${{ steps.run-workflow.outputs.publish_python }}
@@ -262,7 +262,7 @@ jobs:
       needs.run-workflow.outputs.publish_python == 'true'
       && inputs.mode != 'pr' }}
     name: Publish Python SDK
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: [run-workflow]
     defaults:
       run:
@@ -353,7 +353,7 @@ jobs:
       needs.run-workflow.outputs.publish_typescript == 'true'
       && inputs.mode != 'pr' }}
     name: Publish Typescript SDK
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: [run-workflow]
     defaults:
       run:
@@ -423,7 +423,7 @@ jobs:
       needs.run-workflow.outputs.publish_java == 'true'
       && inputs.mode != 'pr' }}
     name: Publish Java SDK
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: [run-workflow]
     defaults:
       run:
@@ -509,7 +509,7 @@ jobs:
       needs.run-workflow.outputs.publish_ruby == 'true'
       && inputs.mode != 'pr' }}
     name: Publish Ruby SDK
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: [run-workflow]
     defaults:
       run:
@@ -584,7 +584,7 @@ jobs:
       needs.run-workflow.outputs.publish_csharp == 'true'
       && inputs.mode != 'pr' }}
     name: Publish C# SDK
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: [run-workflow]
     defaults:
       run:
@@ -649,7 +649,7 @@ jobs:
       needs.run-workflow.outputs.publish_php == 'true'
       && inputs.mode != 'pr' }}
     name: Publish PHP SDK
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: [run-workflow]
     defaults:
       run:

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -4,7 +4,11 @@ on:
   workflow_call:
     inputs:
       runs-on:
-        description: The GitHub Action Runner
+        description: |-
+          Define the type of machine to run the job on. This can be a single string value or a JSON-encoded string value
+          to define a runs-on compatible array/object, such as '["one", "two"]'. Refer to the GitHub Actions
+          documentation at https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on
+          for more details about runs-on values.
         default: ubuntu-22.04
         required: false
         type: string


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/GEN-1437/feature-update-runs-on-input-to-accept-group-format-in-github-action
Reference: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_callinputsinput_idtype

GitHub does not accept non-primitive types for workflow_call event inputs, so this introduces JSON string parsing. This should enable callers to pass any job `runs-on` compatible data, such as:

* string: `runs-on: ubuntu-latest`
* array: `runs-on: '["ubuntu", "example"]'`
* object: `runs-on: '{"group": "example"}'`