### PR TITLE
chore: Support pull_request events for building and publishing Docker image

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -39,6 +39,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=ref,event=pr
             type=ref,event=tag
             type=sha,format=long
 


### PR DESCRIPTION
This will enable GitHub Actions to automatically build and publish Docker images for pull requests rather than requiring Git tagged releases. In these pull requests, references to the Docker image (e.g. `@v15`) can be temporarily updated to point at the Docker image PR tag (`@pr-` prefix and PR number) or SHA tag (`@sha-` prefix and SHA) for easier image update testing.