### PR TITLE
fix: Ensure mcp-typescript target correctly sets publish_mcp_typescript output if NPM is configured

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pb33f/libopenapi v0.15.14
 	github.com/pkg/errors v0.9.1
 	github.com/speakeasy-api/git-diff-parser v0.0.3
-	github.com/speakeasy-api/sdk-gen-config v1.30.1
+	github.com/speakeasy-api/sdk-gen-config v1.31.2
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.15.4
 	github.com/speakeasy-api/versioning-reports v0.6.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/skeema/knownhosts v1.2.1 h1:SHWdIUa82uGZz+F+47k8SY4QhhI291cXCpopT1lK2
 github.com/skeema/knownhosts v1.2.1/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/speakeasy-api/git-diff-parser v0.0.3 h1:LL12d+HMtSyj6O/hQqIn/lgDPYI6ci/DEhk0la/xA+0=
 github.com/speakeasy-api/git-diff-parser v0.0.3/go.mod h1:P46HmmVVmwA9P8h2wa0fDpmRM8/grbVQ+uKhWDtpkIY=
-github.com/speakeasy-api/sdk-gen-config v1.30.1 h1:61gH9i7ZRL2FDpPIkYMY+PmuQjnvUhhBuLTJp8FrNIU=
-github.com/speakeasy-api/sdk-gen-config v1.30.1/go.mod h1:e9PjnCRHGa4K4EFKVU+kKmihOZjJ2V4utcU+274+bnQ=
+github.com/speakeasy-api/sdk-gen-config v1.31.2 h1:5xquHCkMr/IVt/EUfU0wsu8pj5EFFm3Q7/398kZOCWI=
+github.com/speakeasy-api/sdk-gen-config v1.31.2/go.mod h1:e9PjnCRHGa4K4EFKVU+kKmihOZjJ2V4utcU+274+bnQ=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.15.4 h1:lPVNakwHrrRWRaNIdIHE6BK7RI6B/jpdwbtvI/xPEYo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.15.4/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
 github.com/speakeasy-api/versioning-reports v0.6.0 h1:oLokEQ7xnDXqWAQk60Sk+ifwYaRbq3BrLX2KyT8gWxE=

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -1,0 +1,226 @@
+package run_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/speakeasy-api/sdk-gen-config/workflow"
+	"github.com/speakeasy-api/sdk-generation-action/internal/run"
+)
+
+func TestAddTargetPublishOutputs(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		target          workflow.Target
+		installationURL *string
+		expectedOutputs map[string]string
+	}{
+		"csharp-no-publishing": {
+			target: workflow.Target{
+				Publishing: nil, // intentionally no publishing config
+				Target:     "csharp",
+			},
+			expectedOutputs: map[string]string{
+				"publish_csharp": "false",
+			},
+		},
+		"csharp-publishing": {
+			target: workflow.Target{
+				Publishing: &workflow.Publishing{
+					Nuget: &workflow.Nuget{
+						APIKey: "non-empty",
+					},
+				},
+				Target: "csharp",
+			},
+			expectedOutputs: map[string]string{
+				"publish_csharp": "true",
+			},
+		},
+		"go-publishing": {
+			target: workflow.Target{
+				Publishing: nil, // intentionally no publishing config, Go does not use
+				Target:     "go",
+			},
+			expectedOutputs: map[string]string{
+				"publish_go": "true",
+			},
+		},
+		"java-no-publishing": {
+			target: workflow.Target{
+				Publishing: nil, // intentionally no publishing config
+				Target:     "java",
+			},
+			expectedOutputs: map[string]string{
+				"publish_java": "false",
+			},
+		},
+		"java-publishing": {
+			target: workflow.Target{
+				Publishing: &workflow.Publishing{
+					Java: &workflow.Java{
+						GPGSecretKey:  "non-empty",
+						GPGPassPhrase: "non-empty",
+						OSSHRPassword: "non-empty",
+						OSSRHUsername: "non-empty",
+					},
+				},
+				Target: "java",
+			},
+			expectedOutputs: map[string]string{
+				"publish_java":        "true",
+				"use_sonatype_legacy": "false",
+			},
+		},
+		"mcp-typescript-no-publishing": {
+			target: workflow.Target{
+				Publishing: nil, // intentionally no publishing config
+				Target:     "mcp-typescript",
+			},
+			expectedOutputs: map[string]string{
+				"publish_mcp_typescript": "false",
+			},
+		},
+		"mcp-typescript-publishing": {
+			target: workflow.Target{
+				Publishing: &workflow.Publishing{
+					NPM: &workflow.NPM{
+						Token: "non-empty",
+					},
+				},
+				Target: "mcp-typescript",
+			},
+			expectedOutputs: map[string]string{
+				"publish_mcp_typescript": "true",
+			},
+		},
+		"php-no-publishing": {
+			target: workflow.Target{
+				Publishing: nil, // intentionally no publishing config
+				Target:     "php",
+			},
+			expectedOutputs: map[string]string{
+				"publish_php": "false",
+			},
+		},
+		"php-publishing": {
+			target: workflow.Target{
+				Publishing: &workflow.Publishing{
+					Packagist: &workflow.Packagist{
+						Token:    "non-empty",
+						Username: "non-empty",
+					},
+				},
+				Target: "php",
+			},
+			expectedOutputs: map[string]string{
+				"publish_php": "true",
+			},
+		},
+		"python-no-publishing": {
+			target: workflow.Target{
+				Publishing: nil, // intentionally no publishing config
+				Target:     "python",
+			},
+			expectedOutputs: map[string]string{
+				"publish_python": "false",
+			},
+		},
+		"python-publishing": {
+			target: workflow.Target{
+				Publishing: &workflow.Publishing{
+					PyPi: &workflow.PyPi{
+						Token: "non-empty",
+					},
+				},
+				Target: "python",
+			},
+			expectedOutputs: map[string]string{
+				"publish_python": "true",
+			},
+		},
+		"ruby-no-publishing": {
+			target: workflow.Target{
+				Publishing: nil, // intentionally no publishing config
+				Target:     "ruby",
+			},
+			expectedOutputs: map[string]string{
+				"publish_ruby": "false",
+			},
+		},
+		"ruby-publishing": {
+			target: workflow.Target{
+				Publishing: &workflow.Publishing{
+					RubyGems: &workflow.RubyGems{
+						Token: "non-empty",
+					},
+				},
+				Target: "ruby",
+			},
+			expectedOutputs: map[string]string{
+				"publish_ruby": "true",
+			},
+		},
+		"terraform-no-publishing": {
+			target: workflow.Target{
+				Publishing: nil, // intentionally no publishing config
+				Target:     "terraform",
+			},
+			expectedOutputs: map[string]string{
+				"publish_terraform": "false",
+			},
+		},
+		"terraform-publishing": {
+			target: workflow.Target{
+				Publishing: &workflow.Publishing{
+					Terraform: &workflow.Terraform{
+						GPGPrivateKey: "non-empty",
+						GPGPassPhrase: "non-empty",
+					},
+				},
+				Target: "terraform",
+			},
+			expectedOutputs: map[string]string{
+				"publish_terraform": "true",
+			},
+		},
+		"typescript-no-publishing": {
+			target: workflow.Target{
+				Publishing: nil, // intentionally no publishing config
+				Target:     "typescript",
+			},
+			expectedOutputs: map[string]string{
+				"publish_typescript": "false",
+			},
+		},
+		"typescript-publishing": {
+			target: workflow.Target{
+				Publishing: &workflow.Publishing{
+					NPM: &workflow.NPM{
+						Token: "non-empty",
+					},
+				},
+				Target: "typescript",
+			},
+			expectedOutputs: map[string]string{
+				"publish_typescript": "true",
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// AddTargetPublishOutputs is only additive currently.
+			gotOutputs := make(map[string]string)
+			run.AddTargetPublishOutputs(tc.target, gotOutputs, tc.installationURL)
+
+			// Check if the outputs match the expected outputs
+			if !reflect.DeepEqual(gotOutputs, tc.expectedOutputs) {
+				t.Errorf("expected %v, got %v", tc.expectedOutputs, gotOutputs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/GEN-1670/firehydrant-mcp-not-publishing
Reference: https://github.com/speakeasy-api/sdk-gen-config/pull/85

Currently failing as sdk-gen-config requires update to support `mcp-typescript` target for NPM publishing:

```
--- FAIL: TestAddTargetPublishOutputs (0.00s)
    --- FAIL: TestAddTargetPublishOutputs/mcp-typescript-publishing (0.00s)
        /Users/bflad/src/github.com/speakeasy-api/sdk-generation-action/internal/run/run_test.go:222: expected map[publish_mcp_typescript:true], got map[publish_mcp_typescript:false]
```