### PR TITLE
feat: allow env vars to be passed through to tests

### DIFF
--- a/.github/workflows/sdk-test.yaml
+++ b/.github/workflows/sdk-test.yaml
@@ -11,6 +11,9 @@ on:
         description: "The working directory for running Speakeasy CLI commands in the action"
         required: false
         type: string
+      env_vars:
+        required: false
+        type: string
     secrets:
       github_access_token:
         description: A GitHub access token with read access to the repo
@@ -25,6 +28,10 @@ jobs:
     steps:
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1
+
+      - name: Set dynamic environment variables
+        if: inputs.env_vars != ''
+        run: echo "${{ inputs.env_vars }}" >> $GITHUB_ENV
 
       - name: Check commit message condition
         id: check_commit


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow file `.github/workflows/sdk-test.yaml` to add support for dynamically setting environment variables through an input parameter. The most important changes are as follows:

### Workflow Enhancements:

* Added a new optional input parameter `env_vars` to the workflow, allowing users to specify environment variables dynamically. (`[.github/workflows/sdk-test.yamlR14-R16](diffhunk://#diff-081c0880ef56fa0f76aa9260d7f47f4186435bd7329dbfe0409870bb827c75fcR14-R16)`)
* Introduced a new step in the `jobs` section to set the dynamic environment variables, which appends the specified variables to `$GITHUB_ENV` if the `env_vars` input is provided. (`[.github/workflows/sdk-test.yamlR32-R35](diffhunk://#diff-081c0880ef56fa0f76aa9260d7f47f4186435bd7329dbfe0409870bb827c75fcR32-R35)`)