### PR TITLE
Use local package.json version instead of registry version

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -265,7 +265,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
         run: |
-          VERSION=$(npm view . version)
+          VERSION=$(npm pkg get version | tr -d '"')
           echo "Detected version: $VERSION"
 
           if [[ "$VERSION" == *"-"* ]]; then
@@ -370,7 +370,7 @@ jobs:
       - env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
         run: |
-          VERSION=$(npm view . version)
+          VERSION=$(npm pkg get version | tr -d '"')
           echo "Detected version: $VERSION"
 
           if [[ "$VERSION" == *"-"* ]]; then

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -394,7 +394,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
         run: |
-          VERSION=$(npm view . version)
+          VERSION=$(npm pkg get version | tr -d '"')
           echo "Detected version: $VERSION"
 
           if [[ "$VERSION" == *"-"* ]]; then


### PR DESCRIPTION
Fixes the case where the previous version was the official/latest version, but the current version we want to use to generate the package is a prerelease. This would result in the alpha version being incorrectly recognized as the official version.

**Current status:**
See that the alpha version was recognized as official version

<img width="630" height="250" alt="image" src="https://github.com/user-attachments/assets/6f817c02-7b74-4e51-8b43-4977dce1caed" />

https://github.com/criblio/cribl-control-plane-sdk-typescript/actions/runs/16901476071/job/47881434070

**Status from PR:**

<img width="569" height="239" alt="image" src="https://github.com/user-attachments/assets/a5fd6d04-b545-468e-b05d-c092eab43f81" />



Here is the proof that it works as expected:
https://github.com/criblio/cribl-control-plane-sdk-typescript/actions/runs/16908940172/job/47905334957
