### PR TITLE
fix: Explicitly install and use Gradle 8.14 for Java 11 compatibility

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -473,13 +473,14 @@ jobs:
     steps:
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1
-      - uses: actions/checkout@v3
-      - name: Set up Java
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          java-version: "11"
           distribution: "corretto"
-          cache: "gradle"
+          java-version: "11"
+      - uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+        with:
+          gradle-version: "8.14"
       - name: Publish to Sonatype (legacy)
         run: |-
           pwd

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -468,16 +468,16 @@ jobs:
     steps:
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           ref: ${{ needs.run-workflow.outputs.commit_hash }}
-      - name: Set up Java
-        uses: actions/setup-java@v3
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          java-version: "11"
           distribution: "corretto"
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+          java-version: "11"
+      - uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+        with:
+          gradle-version: "8.14"
       - name: Publish to Sonatype (legacy)
         if: ${{ needs.run-workflow.outputs.use_sonatype_legacy == 'true' }}
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1


### PR DESCRIPTION
Reference: https://docs.gradle.org/9.0.0/release-notes.html#jvm-17

Gradle 9.0.0 is being deployed to GitHub Actions runner images. This new version is incompatible with Java 11 and can return errors such as:

> Gradle requires JVM 17 or later to run. Your build is currently configured to use JVM 11.

This change uses `gradle/actions/setup-gradle` to install Gradle 8.14 and ensure compatibility. If/when Gradle 9.0.0 support is necessary, the workflows may need new inputs for Java/Gradle versions or some additional toolchain/wrapper configuration.