### PR TITLE
fix: recognize only speakeasy authored commits

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -306,7 +306,7 @@ func (g *Git) cherryPick(commitHash string) error {
 	cmd := exec.Command("git",
 		"-c", "user.name="+speakeasyBotName,
 		"-c", "user.email=bot@speakeasyapi.dev",
-		"cherry-pick", commitHash)
+		"cherry-pick", "--allow-empty", commitHash)
 	cmd.Dir = workDir
 	cmd.Env = os.Environ()
 	output, err := cmd.CombinedOutput()

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -42,11 +42,12 @@ type Git struct {
 }
 
 const (
-	speakeasyBotName  = "speakeasybot"
-	speakeasyBotAlias = "speakeasy-bot"
+	speakeasyBotName       = "speakeasybot"
+	speakeasyBotAlias      = "speakeasy-bot"
+	speakeasyGithubBotName = "speakeasy-github[bot]"
 )
 
-var managedAutomationUsers = []string{speakeasyBotName, speakeasyBotAlias}
+var managedAutomationUsers = []string{speakeasyGithubBotName, speakeasyBotName, speakeasyBotAlias}
 
 func New(accessToken string) *Git {
 	ctx := context.Background()
@@ -305,7 +306,7 @@ func (g *Git) cherryPick(commitHash string) error {
 	cmd := exec.Command("git",
 		"-c", "user.name="+speakeasyBotName,
 		"-c", "user.email=bot@speakeasyapi.dev",
-		"cherry-pick", "--allow-empty", commitHash)
+		"cherry-pick", commitHash)
 	cmd.Dir = workDir
 	cmd.Env = os.Environ()
 	output, err := cmd.CombinedOutput()
@@ -496,7 +497,7 @@ func isManagedAutomationCommit(author, committer string) bool {
 
 	for _, user := range managedAutomationUsers {
 		name := strings.ToLower(strings.TrimSpace(user))
-		if author == name || committer == name {
+		if author == name {
 			return true
 		}
 	}


### PR DESCRIPTION
We were incorrectly filtering out commits (commited by speakeasy). A cherry-pick will still be commited by speakeasybot, but the author will be someone else.