### PR TITLE
feat: add node_options input

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -42,6 +42,11 @@ on:
         default: true
         required: false
         type: boolean
+      node_options:
+        description: "Additional Node.js options to pass when publishing the Typescript SDK"
+        required: false
+        type: string
+        default: "--max-old-space-size=4096"
     secrets:
       github_access_token:
         description: A GitHub access token with write access to the repo
@@ -272,6 +277,7 @@ jobs:
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+          NODE_OPTIONS: ${{ inputs.node_options }}
         run: |
           VERSION=$(npm pkg get version | tr -d '"')
           echo "Detected version: $VERSION"

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -264,7 +264,8 @@ jobs:
           uv_version: ${{ inputs.uv_version }}
           github_repository: ${{ inputs.github_repository }}
           enable_sdk_changelog: ${{ inputs.enable_sdk_changelog }}
-          node_options: ${{ inputs.node_options }}
+        env:
+          NODE_OPTIONS: ${{ inputs.node_options }}
       - uses: ravsamhq/notify-slack-action@v2
         if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true' && env.SLACK_WEBHOOK_URL != '' }}
         with:

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -118,6 +118,11 @@ on:
         default: true
         required: false
         type: boolean
+      node_options:
+        description: "Additional Node.js options to pass when publishing the Typescript SDK"
+        required: false
+        type: string
+        default: "--max-old-space-size=4096"
     secrets:
       github_access_token:
         description: A GitHub access token with write access to the repo
@@ -259,6 +264,7 @@ jobs:
           uv_version: ${{ inputs.uv_version }}
           github_repository: ${{ inputs.github_repository }}
           enable_sdk_changelog: ${{ inputs.enable_sdk_changelog }}
+          node_options: ${{ inputs.node_options }}
       - uses: ravsamhq/notify-slack-action@v2
         if: ${{ steps.check-label.outputs.short_circuit_label_trigger != 'true' && env.SLACK_WEBHOOK_URL != '' }}
         with:

--- a/action.yml
+++ b/action.yml
@@ -126,6 +126,11 @@ inputs:
     description: "Enable the new SDK changelog feature"
     default: "false"
     required: false
+  node_options:
+    description: "Additional Node.js options to pass when publishing the Typescript SDK"
+    required: false
+    type: string
+    default: "--max-old-space-size=4096"
 outputs:
   publish_python:
     description: "Whether the Python SDK will be published to PyPi"
@@ -216,6 +221,7 @@ runs:
     OPENAI_API_KEY: ${{ inputs.openai_api_key }}
     OPENAPI_DOC_AUTH_TOKEN: ${{ inputs.openapi_doc_auth_token }}
     PR_CREATION_PAT: ${{ inputs.pr_creation_pat }}
+    NODE_OPTIONS: ${{ inputs.node_options }}
   args:
     - ${{ inputs.speakeasy_version }}
     - ${{ inputs.github_access_token }}
@@ -243,3 +249,4 @@ runs:
     - ${{ inputs.pnpm_version }}
     - ${{ inputs.poetry_version }}
     - ${{ inputs.enable_sdk_changelog }}
+    - ${{ inputs.node_options }}


### PR DESCRIPTION
Aim is to make `NODE_OPTIONS` available anywhere the `npm build` command would be run (publish, generation).