### PR TITLE
fix: reset worktree in signed commits flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ output.txt
 openapi/
 *.iml
 .run
+.vscode/

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -297,10 +297,10 @@ func (g *Git) Reset(args ...string) error {
 	return nil
 }
 
-// syncWorktree synchronizes the local repository state with a remote commit
-// This is used after creating commits via GitHub API to ensure local/remote consistency
-func (g *Git) syncWorktree(worktree *git.Worktree, branchName string) error {
-	logging.Debug("Synchronizing local repository with remote branch %s", branchName)
+// resetWorktree resets the given worktree to a clean state.
+// This is used after creating commits via GitHub API to ensure local consistency
+func (g *Git) resetWorktree(worktree *git.Worktree, branchName string) error {
+	logging.Debug("Resetting local repository with remote branch %s", branchName)
 
 	// Hard reset the worktree to the current HEAD to ensure a clean state
 	head, _ := g.repo.Head()
@@ -310,17 +310,6 @@ func (g *Git) syncWorktree(worktree *git.Worktree, branchName string) error {
 		Commit: head.Hash(),
 	}); err != nil {
 		return fmt.Errorf("error resetting to HEAD %s: %w", head.Hash(), err)
-	}
-
-	// Update the local branch reference to point to the latest remote commit
-	if err := worktree.Pull(&git.PullOptions{
-		Auth: getGithubAuth(g.accessToken),
-	}); err != nil && err != git.NoErrAlreadyUpToDate {
-		return fmt.Errorf("error pulling latest changes: %w", err)
-	}
-	headAfter, _ := g.repo.Head()
-	if head.Hash() != headAfter.Hash() {
-		logging.Debug("Updated local HEAD to hash %s", headAfter.Hash())
 	}
 
 	return nil
@@ -695,12 +684,10 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 	}
 	g.client.Git.UpdateRef(context.Background(), owner, repo, newRef, true)
 
-	// Synchronize local repository state with the remote commit we just created
-	// This prevents subsequent checkout operations from failing due to local/remote mismatch
-	if err := g.syncWorktree(w, branch); err != nil {
-		return "", fmt.Errorf("error syncing worktree: %w", err)
+	// This prevents subsequent checkout operations from failing due to uncommitted changes
+	if err := g.resetWorktree(w, branch); err != nil {
+		return "", fmt.Errorf("error resetting worktree: %w", err)
 	}
-	logging.Debug("Successfully synchronized local repository with remote commit %s", *commitResult.SHA)
 
 	return *commitResult.SHA, nil
 }
@@ -1622,7 +1609,7 @@ func runGitCommand(args ...string) (string, error) {
 }
 
 func pushErr(err error) error {
-	if err != nil && err != git.NoErrAlreadyUpToDate {
+	if err != nil {
 		if strings.Contains(err.Error(), "protected branch hook declined") {
 			return fmt.Errorf("error pushing changes: %w\nThis is likely due to a branch protection rule. Please ensure that the branch is not protected (repo > settings > branches)", err)
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1609,7 +1609,7 @@ func runGitCommand(args ...string) (string, error) {
 }
 
 func pushErr(err error) error {
-	if err != nil {
+	if err != nil && err != git.NoErrAlreadyUpToDate {
 		if strings.Contains(err.Error(), "protected branch hook declined") {
 			return fmt.Errorf("error pushing changes: %w\nThis is likely due to a branch protection rule. Please ensure that the branch is not protected (repo > settings > branches)", err)
 		}


### PR DESCRIPTION
## Why? 
We weren't resetting the local index(staging area) as part of the signed commits flow that prevented subsequent checkout steps from suceeding.

## Context
The signed commit flow roughly looks like this:
- Stage files using a local `git add .`
- Perform a signed commit:
  - Create a Tree object in the Git database [using the GH API](https://docs.github.com/en/rest/git/trees?apiVersion=2022-11-28#create-a-tree). We loop over staged files and include relevant entries in the tree.
  - Create a commit [referencing the tree SHA](https://github.com/speakeasy-api/sdk-generation-action/blob/main/internal/git/git.go#L655). This is transparently a signed commit since GitHub automatically signs commits made by GitHub Apps with GitHub's own signing key.

We then checkout to the target branch within the finalize step [here](https://github.com/speakeasy-api/sdk-generation-action/blob/main/internal/actions/runWorkflow.go#L266). 

It is at this point that the workflow fails. The reason for failure is that the local index(staging area) has uncommitted changes due to the earlier `git add .`. 

## What changed
The fix I implemented was to hard reset the local worktree to the current HEAD.


GEN-1847