### PR TITLE
chore: Use -A flag in git add to handle deleted files

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -751,12 +751,13 @@ func (g *Git) createAndPushTree(ref *github.Reference, sourceFiles git.Status) (
 
 func (g *Git) Add(arg string) error {
 	// We execute this manually because go-git doesn't properly support gitignore
-	cmd := exec.Command("git", "add", arg)
+	// Use -A flag to properly handle deleted files during SDK regeneration
+	cmd := exec.Command("git", "add", "-A", arg)
 	cmd.Dir = filepath.Join(environment.GetWorkspace(), "repo", environment.GetWorkingDirectory())
 	cmd.Env = os.Environ()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("error running `git add %s`: %w %s", arg, err, string(output))
+		return fmt.Errorf("error running `git add -A %s`: %w %s", arg, err, string(output))
 	}
 
 	return nil


### PR DESCRIPTION
Problem:
During SDK regeneration, when files are deleted from the generated SDK, the git workflow was not properly staging these deletions. The git add <path> command only stages new and modified files, but ignores deleted files. This caused deleted files to remain in the repository even after regeneration, leading to stale files persisting in the SDK.

Solution:
  Modified the Add() function in internal/git/git.go:754 to use `git add -A`. The -A flag stages all changes in the working directory, including:
  - New files
  - Modified files
  - Deleted files (the key fix)