### PR TITLE
chore: bump NPM CLI version

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -274,32 +274,6 @@ jobs:
         run: npm install --ignore-scripts
       - name: Install bun
         run: npm rebuild bun
-      - name: Debug OIDC environment
-        env:
-          NPM_TOKEN: ${{ secrets.npm_token }}
-        run: |
-          echo "=== npm/node versions ==="
-          npm --version
-          node --version
-          echo ""
-          echo "=== OIDC environment variables ==="
-          if [ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ]; then
-            echo "ACTIONS_ID_TOKEN_REQUEST_URL: $ACTIONS_ID_TOKEN_REQUEST_URL"
-          else
-            echo "ACTIONS_ID_TOKEN_REQUEST_URL: NOT SET"
-          fi
-          if [ -n "$ACTIONS_ID_TOKEN_REQUEST_TOKEN" ]; then
-            echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: SET (length: ${#ACTIONS_ID_TOKEN_REQUEST_TOKEN})"
-          else
-            echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: NOT SET"
-          fi
-          echo ""
-          echo "=== npm authentication config ==="
-          if [ -n "$NPM_TOKEN" ]; then
-            echo "NPM_TOKEN: SET (length: ${#NPM_TOKEN})"
-          else
-            echo "NPM_TOKEN: NOT SET"
-          fi
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
[CS-275](https://linear.app/speakeasy/issue/CS-275/feature-support-trusted-publishers-npm)
[RFC](https://www.notion.so/speakeasyapi/RFC-NPM-Trusted-Publishing-29c726c497cc805f9674c0918e52e7c5?v=99bac25b265e455c871a0c3abc64f191&source=copy_link)

This PR bumps node version to `24.x` [Active LTS](https://nodejs.org/en/about/previous-releases)  ( >= [22.9.0](https://github.com/npm/cli/blob/v11.5.1/package.json#L258) minimum to satisfy `npm CLI >= 11.5.1`, which is required by [NPM Trusted Publishing](https://docs.npmjs.com/trusted-publishers) )

Note: `actions/setup-node@v3` was not sufficient to install `node 24.x`, I used the same commit that is [already used for MCP](https://github.com/speakeasy-api/sdk-generation-action/blob/main/.github/workflows/sdk-publish.yaml#L379)

