### PR TITLE
fix: bump NPM CLI version for publishing in direct mode

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -93,9 +93,6 @@ on:
       nuget_api_key:
         description: The api key for publishing to Nuget
         required: false
-
-permissions: inherit
-
 jobs:
   release:
     name: Create Github Release

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -170,9 +170,6 @@ on:
       nuget_api_key:
         description: The api key for publishing to the Nuget registry
         required: false
-
-permissions: inherit
-
 jobs:
   run-workflow:
     name: Generate Target
@@ -404,9 +401,9 @@ jobs:
         with:
           ref: ${{ needs.run-workflow.outputs.commit_hash }}
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "16.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: npm install --ignore-scripts


### PR DESCRIPTION
CS-275

Erratum on https://github.com/speakeasy-api/sdk-generation-action/pull/266  (missed `workflow-executor.yaml` for publishing in `direct` mode)  -__-

Successfully tested it [here](https://github.com/2ynn/speakeasy-bar-typescript/actions/runs/19112575981/job/54613368198) to publish [v4.4.9](https://www.npmjs.com/package/@2ynn/speakeasy-bar/v/4.4.9#provenance) on test package
