### PR TITLE
fix: Default poetry to 2.2.1 to prevent Python 3.9 errors

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -29,6 +29,7 @@ on:
         description: "The version of poetry to use"
         required: false
         type: string
+        default: "2.2.1"
       uv_version:
         description: "The version of uv to use"
         required: false

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -109,6 +109,7 @@ on:
         description: "Version of poetry to install. Not recommended for use without consulting Speakeasy support."
         required: false
         type: string
+        default: "2.2.1"
       uv_version:
         description: "Version of uv to install. Not recommended for use without consulting Speakeasy support."
         required: false


### PR DESCRIPTION
Reference: https://github.com/python-poetry/poetry/releases/tag/2.3.0

Poetry 2.3.0 dropped Python 3.9 support. Speakeasy generation and publishing still supports Python 3.9. Without this default version pinning, runs install the latest version (2.3.0) and get an opaque error:

```
Installing Poetry (2.3.0)
Installing Poetry (2.3.0): Creating environment
Installing Poetry (2.3.0): Installing Poetry
Installing Poetry (2.3.0): An error occurred. Removing partial environment.
Poetry installation failed.
See /.../poetry-installer-error-uuey_d_v.log for error logs.
```

Installing via pip directly (similar to install script) shows reason:

```
ERROR: Ignored the following versions that require a different python version: 2.3.0 Requires-Python <4.0,>=3.10
ERROR: Could not find a version that satisfies the requirement poetry==2.3.0 (from versions:  ...)
ERROR: No matching distribution found for poetry==2.3.0
```