### PR TITLE
fix: Use explicit GOTOOLCHAIN=auto to enable Go toolchain upgrades for customer generations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ RUN go build -o /action
 ## Deploy
 FROM golang:1.23-alpine3.21
 
+# Enable Go toolchain automatic upgrades to prevent Go version errors in
+# customer generations (GOTOOLCHAIN=local default in golang images)
+ENV GOTOOLCHAIN=auto
+
 RUN apk update
 
 ### Install common tools


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/TFGEN-280/bug-customer-go-version-issues-with-latest-workflow
Reference: https://github.com/docker-library/golang/issues/472

While the image default makes sense for typical Go projects, the Go version selection is customer controlled for this usage. Therefore, overwrite the image default of `GOTOOLCHAIN=local` with `GOTOOLCHAIN=auto` to re-enable automatic Go toolchain upgrades.