### PR TITLE
feat: Upgrade Alpine Linux for Go 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## Build
-FROM golang:1.23-alpine3.21 AS builder
+FROM golang:1.24-alpine3.22 AS builder
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ COPY pkg/ ./pkg/
 RUN go build -o /action
 
 ## Deploy
-FROM golang:1.23-alpine3.21
+FROM golang:1.24-alpine3.22
 
 # Enable Go toolchain automatic upgrades to prevent Go version errors in
 # customer generations (GOTOOLCHAIN=local default in golang images)

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Dev Stage - Includes build tools, compilers, and source code
-FROM golang:1.23-alpine3.21 AS dev
+FROM golang:1.24-alpine3.22 AS dev
 
 # Install development tools
 RUN apk update && apk add --no-cache \


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/TFGEN-280/bug-customer-go-version-issues-with-latest-workflow

While the `GOTOOLCHAIN=auto` approach previously added can help with customer-defined Go versions for Go module builds, it inherently does not make `go install` work for `staticcheck` installation which is automatically ran by the generator:

```
» go install honnef.co/go/tools/cmd/staticcheck@latest...

» staticcheck -checks=inherit,-SA1019 ./......

INFO    Running command: staticcheck -checks=inherit,-SA1019 ./...	{"path":"/github/workspace/repo"}
WARN    failed running commands:
-: module requires at least go1.24, but Staticcheck was built with go1.23.12 (compile)
-: module requires at least go1.24.0, but Staticcheck was built with go1.23.12 (compile)
-: module requires at least go1.24.11, but Staticcheck was built with go1.23.12 (compile)
```

Rather than attempt to further manipulate `GOTOOLCHAIN` during generation commands or setup tools in `go.mod` (which has its own host of issues, including unneeded dependency management) to workaround this, this change upgrades the Go-based image to 1.24 which necessitates the Alpine Linux bump.