### PR TITLE
fix: find existing PRs with legacy titles (without bee emoji)

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -211,8 +211,11 @@ func (g *Git) FindExistingPR(branchName string, action environment.Action, sourc
 		prTitle = prTitle + " [" + sanitizedSourceBranch + "]"
 	}
 
+	// Also check for legacy PR titles (without the bee emoji)
+	legacyPrTitle := strings.ReplaceAll(prTitle, "🐝 ", "")
+
 	for _, p := range prs {
-		if strings.HasPrefix(p.GetTitle(), prTitle) {
+		if strings.HasPrefix(p.GetTitle(), prTitle) || strings.HasPrefix(p.GetTitle(), legacyPrTitle) {
 			logging.Info("Found existing PR %s", *p.Title)
 
 			if branchName != "" && p.GetHead().GetRef() != branchName {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -839,6 +839,47 @@ func TestCreateOrUpdateDocsPR_SourceBranchAware(t *testing.T) {
 	}
 }
 
+func TestLegacyPRTitleWithoutBee(t *testing.T) {
+	// During a bug period, PR titles were created without the bee emoji.
+	// We need to ensure we can find those legacy PRs by stripping the bee.
+	withoutBee := func(s string) string {
+		return strings.ReplaceAll(s, "🐝 ", "")
+	}
+
+	tests := []struct {
+		name     string
+		current  string
+		expected string
+	}{
+		{
+			name:     "SDK PR title",
+			current:  speakeasyGenPRTitle,
+			expected: "chore: Update SDK - ",
+		},
+		{
+			name:     "Specs PR title",
+			current:  speakeasyGenSpecsTitle,
+			expected: "chore: Update Specs - ",
+		},
+		{
+			name:     "Docs PR title",
+			current:  speakeasyDocsPRTitle,
+			expected: "chore: Update SDK Docs - ",
+		},
+		{
+			name:     "Suggest PR title",
+			current:  speakeasySuggestPRTitle,
+			expected: "chore: Suggest OpenAPI changes - ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, withoutBee(tt.current))
+		})
+	}
+}
+
 func TestCreateSuggestionPR_SourceBranchAware(t *testing.T) {
 	tests := []struct {
 		name                  string


### PR DESCRIPTION
## Summary
- During a bug period, PR titles were briefly formatted without the bee emoji (e.g., `chore: Update SDK -` instead of `chore: 🐝 Update SDK -`)
- `FindExistingPR` now also checks for legacy PR titles by stripping the bee emoji from the expected prefix
- Added unit test to verify the legacy title format mapping

## Test plan
- [x] Unit tests pass (`go test ./internal/git/...`)
- [x] New `TestLegacyPRTitleWithoutBee` test verifies bee removal produces expected legacy formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)