### PR TITLE
chore: pass ActionURL to PRDescriptionInput

### DIFF
--- a/internal/cli/prdescription.go
+++ b/internal/cli/prdescription.go
@@ -34,6 +34,7 @@ type PRDescriptionInput struct {
 	// Version information
 	SpeakeasyVersion string `json:"speakeasy_version,omitempty"`
 	ManualBump       bool   `json:"manual_bump,omitempty"`
+	ActionRunURL     string `json:"action_run_url,omitempty"`
 
 	// Version report data
 	VersionReport *versioning.MergedVersionReport `json:"version_report,omitempty"`

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -334,6 +334,15 @@ func GetGithubServerURL() string {
 	return os.Getenv("GITHUB_SERVER_URL")
 }
 
+func GetActionRunURL(repo string) string {
+	serverURL := os.Getenv("GITHUB_SERVER_URL")
+	runID := os.Getenv("GITHUB_RUN_ID")
+	if serverURL == "" || repo == "" || runID == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s/actions/runs/%s", serverURL, repo, runID)
+}
+
 func GetGithubOIDCRequestURL() string {
 	return os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1032,6 +1032,7 @@ func (g *Git) tryGeneratePRDescriptionViaCLI(info PRInfo) *cli.PRDescriptionOutp
 	if info.ReleaseInfo != nil {
 		input.SpeakeasyVersion = info.ReleaseInfo.SpeakeasyVersion
 	}
+	input.ActionRunURL = environment.GetActionRunURL(environment.GetRepo())
 
 	output, err := cli.GeneratePRDescription(input)
 	if err != nil {


### PR DESCRIPTION
GEN-2166

To be merged alongside: https://github.com/speakeasy-api/speakeasy/pull/1874

This PR passes the `ActionURL` to the `PRDescriptionInput` so it can be displayed in the [footer](https://github.com/speakeasy-api/speakeasy-client-sdk-csharp/pull/42) to ease troubleshooting