### PR TITLE
WIP: remove job-level permissions from publish-mcp-registry to unblock callers

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -559,9 +559,6 @@ jobs:
     if: ${{ needs.release.outputs.publish_mcp_registry == 'true' && needs.publish-npm-mcp.result == 'success' }}
     name: Publish to MCP Registry
     runs-on: ${{ ((startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{') || startsWith(inputs.runs-on, '"')) && fromJSON(inputs.runs-on)) || inputs.runs-on }}
-    permissions:
-      id-token: write # Required for github-oidc authentication
-      contents: read
     needs:
       - release
       - publish-npm-mcp


### PR DESCRIPTION
## Summary

- PR #321 added a `publish-mcp-registry` job with `permissions: id-token: write` to `sdk-publish.yaml`
- GitHub validates reusable workflow permissions **statically at parse time**, so every customer calling `@v15` without `id-token: write` in their caller workflow now gets a parse error — even if they don't use MCP at all
- This affects ~80+ customer workflow files referencing `@v15`
- Codatio reported this via `codatio/client-sdk-typescript`

The fix removes the job-level `permissions` block. Customers who need OIDC auth for MCP registry publishing should add `id-token: write` to their own calling workflow.

Fixes GEN-2889

## Test plan

- [ ] Verify a customer workflow without `id-token: write` (e.g. Codatio's) no longer fails at parse time
- [ ] Verify MCP registry publishing still works for customers who add `id-token: write` to their caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)