### PR TITLE
fix: set Tagger in CreateTag to unblock CLI/TF publish (CLI-15)

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1629,6 +1629,11 @@ func (g *Git) CreateTag(tag string, hash string) error {
 
 	if _, err := g.repo.CreateTag(tag, plumbing.NewHash(hash), &git.CreateTagOptions{
 		Message: tag,
+		Tagger: &object.Signature{
+			Name:  speakeasyBotName,
+			Email: "bot@speakeasyapi.dev",
+			When:  time.Now(),
+		},
 	}); err != nil {
 		logging.Info("Failed to create tag: %s", err)
 		return err

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -880,6 +880,38 @@ func TestLegacyPRTitleWithoutBee(t *testing.T) {
 	}
 }
 
+// TestGit_CreateTag_WithoutUserConfig exercises the production scenario where the
+// Docker image has no git user.name/user.email in any config scope. Without an
+// explicit Tagger in CreateTagOptions, go-git returns ErrMissingTagger.
+func TestGit_CreateTag_WithoutUserConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	repoPath := t.TempDir()
+	repo, err := git.PlainInit(repoPath, false)
+	require.NoError(t, err)
+
+	w, err := repo.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(repoPath, "a.txt"), []byte("x"), 0o644))
+	_, err = w.Add("a.txt")
+	require.NoError(t, err)
+	hash, err := w.Commit("initial", &git.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@example.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	g := &Git{repo: repo}
+	require.NoError(t, g.CreateTag("v1.0.0", hash.String()))
+
+	ref, err := repo.Tag("v1.0.0")
+	require.NoError(t, err)
+	tagObj, err := repo.TagObject(ref.Hash())
+	require.NoError(t, err, "tag should be annotated (have a tag object), not lightweight")
+	assert.Equal(t, speakeasyBotName, tagObj.Tagger.Name)
+	assert.Equal(t, "bot@speakeasyapi.dev", tagObj.Tagger.Email)
+}
+
 func TestGit_PushTag(t *testing.T) {
 	workspace := t.TempDir()
 	repoPath := filepath.Join(workspace, "repo")


### PR DESCRIPTION
## Summary

- Fixes [CLI-15](https://linear.app/speakeasy/issue/CLI-15/sdk-publish-cli-target-fails-with-tagger-field-is-required): `sdk-publish.yaml@v15` release step fails for CLI targets with `Error: failed to create tag: tagger field is required`.
- `(*Git).CreateTag` calls go-git's `CreateTag` with only `Message` set. With a non-empty `Message`, go-git treats it as an annotated tag and requires a `Tagger`. Nil `Tagger` → falls back to `user.name`/`user.email` from repo/global/system git config. The Docker action image has none of these, so it returns `ErrMissingTagger` deterministically.
- Pass an explicit `Tagger` (`speakeasybot` / `bot@speakeasyapi.dev`) matching the existing commit `Author` pattern at `git.go:636`. Closes both the visible CLI regression and the latent Terraform hazard.

## Why this surfaced now

This function has been broken since PR #28 (2023) for the Terraform branch, but every major TF customer I checked bypasses the Docker workflow for their own reasons.
 PR #318 introduced the CLI publish path through the same broken function — and CLI customers can't bypass it because `publish-cli`'s goreleaser step consumes the tag created by the Docker `release` job. H

## Reproduction (pre-fix)

Reproduced the exact error in a clean alpine3.23 container that mirrors the production Dockerfile three ways:
1. Bare `PlainInit` + `CreateTag` → fails
2. Full `PlainClone` + `configureSystemGitAuth` (same as prod) + `CreateTag` → fails
3. With `GIT_AUTHOR_*` / `EMAIL` / `USER` env vars set → still fails (go-git v5.11.0 reads config files only, not env vars)

## Test plan

- [x] New regression test `TestGit_CreateTag_WithoutUserConfig` isolates `HOME` and `XDG_CONFIG_HOME` to empty tempdirs, mirroring the prod container, and verifies (a) `CreateTag` succeeds, (b) the resulting tag is annotated with a tag object, (c) the tagger identity matches `speakeasybot` / `bot@speakeasyapi.dev`.
- [x] Existing `TestGit_PushTag` still passes (explicit `Tagger` takes precedence over config, so no regression for test envs that set config via CLI).
- [x] Full `go test ./internal/git/` suite green.
- [ ] Run a customer CLI publish end-to-end against this branch's action image to confirm goreleaser picks up the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)