### PR TITLE
chore: surface missing object hash when go-git push hits ErrObjectNotFound

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -39,6 +39,7 @@ type Git struct {
 	accessToken string
 	repo        *git.Repository
 	client      *github.Client
+	storerLog   *loggingStorer
 }
 
 const (
@@ -94,6 +95,8 @@ func (g *Git) CloneRepo() error {
 	if err != nil {
 		return fmt.Errorf("failed to clone repo: %w", err)
 	}
+	g.storerLog = newLoggingStorer(r.Storer)
+	r.Storer = g.storerLog
 	g.repo = r
 
 	if err := g.configureSystemGitAuth(repoDir); err != nil {
@@ -645,11 +648,14 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 			return "", fmt.Errorf("error committing changes: %w", err)
 		}
 
+		if g.storerLog != nil {
+			g.storerLog.reset()
+		}
 		if err := g.repo.Push(&git.PushOptions{
 			Auth:  getGithubAuth(g.accessToken),
 			Force: true, // This is necessary because at the beginning of the workflow we reset the branch
 		}); err != nil {
-			return "", pushErr(err)
+			return "", g.pushErr(err)
 		}
 		return commitHash.String(), nil
 	}
@@ -1323,10 +1329,13 @@ func (g *Git) MergeBranch(branchName string) (string, error) {
 		return "", fmt.Errorf("error getting head ref: %w", err)
 	}
 
+	if g.storerLog != nil {
+		g.storerLog.reset()
+	}
 	if err := g.repo.Push(&git.PushOptions{
 		Auth: getGithubAuth(g.accessToken),
 	}); err != nil {
-		return "", pushErr(err)
+		return "", g.pushErr(err)
 	}
 
 	return headRef.Hash().String(), nil
@@ -1708,10 +1717,15 @@ func runGitCommand(args ...string) (string, error) {
 	return outb.String(), nil
 }
 
-func pushErr(err error) error {
+func (g *Git) pushErr(err error) error {
 	if err != nil && err != git.NoErrAlreadyUpToDate {
 		if strings.Contains(err.Error(), "protected branch hook declined") {
 			return fmt.Errorf("error pushing changes: %w\nThis is likely due to a branch protection rule. Please ensure that the branch is not protected (repo > settings > branches)", err)
+		}
+		if errors.Is(err, plumbing.ErrObjectNotFound) && g.storerLog != nil {
+			if h, stack, ok := g.storerLog.lastMissingObject(); ok {
+				return fmt.Errorf("error pushing changes: %w (missing object %s)\nstorer lookup stack:\n%s", err, h, stack)
+			}
 		}
 		return fmt.Errorf("error pushing changes: %w", err)
 	}

--- a/internal/git/storerlog.go
+++ b/internal/git/storerlog.go
@@ -1,0 +1,63 @@
+package git
+
+import (
+	"errors"
+	"runtime/debug"
+	"sync"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage"
+)
+
+// loggingStorer wraps a storage.Storer and records the hash of the most
+// recent object lookup that returned plumbing.ErrObjectNotFound, along
+// with the Go stack trace captured at that call site.
+//
+// This exists purely so pushErr can attach diagnostic context when go-git
+// returns its otherwise-bare "object not found" error during push. The
+// wrapper delegates every storer method to the underlying storer via
+// field embedding; only EncodedObject is intercepted.
+type loggingStorer struct {
+	storage.Storer
+	mu          sync.Mutex
+	lastMissing plumbing.Hash
+	lastStack   []byte
+}
+
+func newLoggingStorer(underlying storage.Storer) *loggingStorer {
+	return &loggingStorer{Storer: underlying}
+}
+
+func (s *loggingStorer) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+	obj, err := s.Storer.EncodedObject(t, h)
+	if err != nil && errors.Is(err, plumbing.ErrObjectNotFound) {
+		stack := debug.Stack()
+		s.mu.Lock()
+		s.lastMissing = h
+		s.lastStack = stack
+		s.mu.Unlock()
+	}
+	return obj, err
+}
+
+// lastMissingObject returns the hash and stack of the most recent lookup
+// that returned ErrObjectNotFound. The bool is false if nothing has been
+// recorded yet.
+func (s *loggingStorer) lastMissingObject() (plumbing.Hash, []byte, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.lastMissing.IsZero() {
+		return plumbing.ZeroHash, nil, false
+	}
+	return s.lastMissing, s.lastStack, true
+}
+
+// reset clears any previously recorded miss. Call this before a push so
+// the captured record reflects only that push's lookups, not stale state
+// from earlier fetches or pushes.
+func (s *loggingStorer) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastMissing = plumbing.ZeroHash
+	s.lastStack = nil
+}

--- a/internal/git/storerlog_test.go
+++ b/internal/git/storerlog_test.go
@@ -1,0 +1,87 @@
+package git
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggingStorer_RecordsHashOnMiss(t *testing.T) {
+	wrapped := newLoggingStorer(memory.NewStorage())
+
+	missing := plumbing.NewHash("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	_, err := wrapped.EncodedObject(plumbing.AnyObject, missing)
+	require.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+
+	h, stack, ok := wrapped.lastMissingObject()
+	require.True(t, ok, "expected a miss to be recorded")
+	require.Equal(t, missing, h)
+	require.NotEmpty(t, stack, "expected a non-empty stack trace")
+}
+
+func TestLoggingStorer_DoesNotRecordOnSuccess(t *testing.T) {
+	store := memory.NewStorage()
+	obj := store.NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+	w, err := obj.Writer()
+	require.NoError(t, err)
+	_, err = w.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	hash, err := store.SetEncodedObject(obj)
+	require.NoError(t, err)
+
+	wrapped := newLoggingStorer(store)
+	got, err := wrapped.EncodedObject(plumbing.AnyObject, hash)
+	require.NoError(t, err)
+	require.Equal(t, hash, got.Hash())
+
+	_, _, ok := wrapped.lastMissingObject()
+	require.False(t, ok, "successful lookup should not record a miss")
+}
+
+func TestLoggingStorer_ResetClearsRecord(t *testing.T) {
+	wrapped := newLoggingStorer(memory.NewStorage())
+
+	_, err := wrapped.EncodedObject(plumbing.AnyObject, plumbing.NewHash("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"))
+	require.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+	_, _, ok := wrapped.lastMissingObject()
+	require.True(t, ok)
+
+	wrapped.reset()
+
+	_, _, ok = wrapped.lastMissingObject()
+	require.False(t, ok, "reset should clear the recorded miss")
+}
+
+func TestPushErr_EnrichesErrObjectNotFoundWithMissingHash(t *testing.T) {
+	g := &Git{storerLog: newLoggingStorer(memory.NewStorage())}
+
+	missing := plumbing.NewHash("cafebabecafebabecafebabecafebabecafebabe")
+	_, err := g.storerLog.EncodedObject(plumbing.AnyObject, missing)
+	require.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+
+	wrapped := g.pushErr(plumbing.ErrObjectNotFound)
+	require.Error(t, wrapped)
+
+	msg := wrapped.Error()
+	require.Contains(t, msg, "error pushing changes")
+	require.Contains(t, msg, "missing object "+missing.String())
+	require.Contains(t, msg, "storer lookup stack")
+}
+
+func TestPushErr_UnchangedForNonObjectNotFoundErrors(t *testing.T) {
+	g := &Git{storerLog: newLoggingStorer(memory.NewStorage())}
+
+	wrapped := g.pushErr(errFake("something else went wrong"))
+	require.Error(t, wrapped)
+	require.False(t, strings.Contains(wrapped.Error(), "missing object"),
+		"non-ObjectNotFound errors should not be enriched")
+}
+
+type errFake string
+
+func (e errFake) Error() string { return string(e) }


### PR DESCRIPTION
## Summary

- When `g.repo.Push` fails with `plumbing.ErrObjectNotFound`, `pushErr` currently wraps it as a bare `error pushing changes: object not found` — no hash, no object type, no indication of where in go-git's push path the lookup happened. That makes this class of failure undiagnosable.
- Adds a passive `loggingStorer` (new file `internal/git/storerlog.go`) that wraps the filesystem storer via interface embedding and intercepts only `EncodedObject`. When a lookup returns `ErrObjectNotFound`, it records the hash and Go stack trace at the call site.
- `pushErr` (now a method on `*Git`) checks whether the underlying push error is `ErrObjectNotFound` and, if so, appends `(missing object <hash>)` plus the storer lookup stack to the returned error.
- The record is `reset()` immediately before each `g.repo.Push` call so the captured state reflects only the failing push, not a stale miss from an earlier fetch or prior push in the same run.

## Why

Context-free `object not found` errors from go-git leave no signal to root-cause from. With the hash and stack in hand, whoever looks at the next failure can tell whether it's a blob/tree that `w.Commit` should have written, a commit reachable from a remote ref but absent locally, or a delta base inside a packfile — each of which has a different fix.

## Tradeoffs

- The wrapper embeds the `storage.Storer` interface, so it doesn't satisfy concrete extensions like `storer.LooseObjectStorer` or `storer.PackfileWriter`. I verified push and fetch don't type-assert on the storer, so those paths are unaffected. `RepackObjects` and `Prune` would fall back to slower paths, but the action doesn't call them today.
- Go-git's push legitimately hits `ErrObjectNotFound` during the ignore-set expansion (`allowMissingObjects=true`). The per-push reset ensures we only report misses from the failing push itself, and the attached stack trace lets a reader tell a legitimate swallowed miss apart from the causal one.

## Test plan

- [x] `go build ./...` clean
- [x] `gofmt -d internal/git/` clean
- [ ] Verify on a run that hits `ErrObjectNotFound` that the wrapped error now includes hash + stack
- [ ] Verify successful pushes produce no extra output and no behavior change

Refs: GEN-2908

🤖 Generated with [Claude Code](https://claude.com/claude-code)