### PR TITLE
feat: add post_generation_script hook (RFC)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -134,6 +134,13 @@ inputs:
     description: "Skip versioning during SDK generation, preventing version bumps"
     default: "false"
     required: false
+  post_generation_script:
+    description: |-
+      Optional shell snippet executed after a successful SDK generation and before changes are committed.
+      Runs from the repository's working_directory via `bash -c`, so any modifications to generated files are included in the same commit/PR.
+      A non-zero exit fails the workflow run; wrap individual commands in `|| true` if you want best-effort behavior.
+      The script runs with a scrubbed environment (PATH, HOME, GITHUB_WORKSPACE, GITHUB_REPOSITORY, etc.) — action secrets like `github_access_token` and `speakeasy_api_key` are NOT exposed. Use `cli_environment_variables` to pass additional variables explicitly.
+    required: false
 outputs:
   publish_python:
     description: "Whether the Python SDK will be published to PyPi"

--- a/internal/actions/runWorkflow.go
+++ b/internal/actions/runWorkflow.go
@@ -1,10 +1,13 @@
 package actions
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v63/github"
 	"github.com/pkg/errors"
@@ -185,6 +188,10 @@ func RunWorkflow() error {
 			return err
 		}
 
+		if err := runPostGenerationScript(); err != nil {
+			return err
+		}
+
 		if _, err := g.CommitAndPush(docVersion, resolvedVersion, "", environment.ActionRunWorkflow, false, runRes.VersioningInfo.VersionReport); err != nil {
 			return err
 		}
@@ -192,6 +199,10 @@ func RunWorkflow() error {
 
 	outputs["resolved_speakeasy_version"] = resolvedVersion
 	if sourcesOnly {
+		if err := runPostGenerationScript(); err != nil {
+			return err
+		}
+
 		if _, err := g.CommitAndPush("", resolvedVersion, "", environment.ActionRunWorkflow, sourcesOnly, nil); err != nil {
 			return err
 		}
@@ -412,6 +423,60 @@ func addDirectModeBranchTagging() error {
 			tags = append(tags, "published")
 		}
 		return cli.Tag(tags, sources, targets)
+	}
+
+	return nil
+}
+
+var postGenerationScriptTimeout = 10 * time.Minute
+
+// postGenerationScriptEnvAllowlist is the set of env vars passed through to the
+// user-provided script. Everything else (GITHUB_TOKEN, INPUT_*, *_API_KEY, OIDC
+// request tokens, ...) is scrubbed so a typo or compromised script can't
+// exfiltrate the action's credentials. Authors who need extra vars can pass
+// them via the `cli_environment_variables` input.
+var postGenerationScriptEnvAllowlist = []string{
+	"PATH", "HOME", "USER", "LANG", "LC_ALL", "TZ", "TMPDIR", "SHELL",
+	"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+	"http_proxy", "https_proxy", "no_proxy",
+	"GITHUB_WORKSPACE", "GITHUB_REPOSITORY", "GITHUB_REF", "GITHUB_SHA",
+	"GITHUB_RUN_ID", "GITHUB_ACTOR", "GITHUB_SERVER_URL", "GITHUB_WORKFLOW",
+	"RUNNER_OS", "RUNNER_ARCH", "RUNNER_TEMP",
+}
+
+func postGenerationScriptEnv() []string {
+	env := make([]string, 0, len(postGenerationScriptEnvAllowlist))
+	for _, k := range postGenerationScriptEnvAllowlist {
+		if v, ok := os.LookupEnv(k); ok {
+			env = append(env, k+"="+v)
+		}
+	}
+	env = append(env, environment.SpeakeasyEnvVars()...)
+	return env
+}
+
+func runPostGenerationScript() error {
+	script := strings.TrimSpace(environment.GetPostGenerationScript())
+	if script == "" {
+		return nil
+	}
+
+	logging.Info("Running post_generation_script (timeout %s)", postGenerationScriptTimeout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), postGenerationScriptTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", "-c", script)
+	cmd.Dir = environment.GetRepoPath()
+	cmd.Env = postGenerationScriptEnv()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("post_generation_script exceeded %s timeout", postGenerationScriptTimeout)
+	}
+	if err != nil {
+		return fmt.Errorf("post_generation_script failed: %w", err)
 	}
 
 	return nil

--- a/internal/actions/run_post_generation_script_test.go
+++ b/internal/actions/run_post_generation_script_test.go
@@ -1,0 +1,182 @@
+package actions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunPostGenerationScript(t *testing.T) {
+	tests := []struct {
+		name      string
+		script    string
+		wantErr   bool
+		errSubstr string
+		// optional: inspect the repo dir after running
+		assertDir func(t *testing.T, repoDir string)
+	}{
+		{
+			name:    "empty script is a no-op",
+			script:  "",
+			wantErr: false,
+		},
+		{
+			name:    "whitespace-only script is a no-op",
+			script:  "   \n\t  ",
+			wantErr: false,
+		},
+		{
+			name:    "successful script returns nil",
+			script:  "echo hello",
+			wantErr: false,
+		},
+		{
+			name:      "non-zero exit is wrapped",
+			script:    "exit 7",
+			wantErr:   true,
+			errSubstr: "post_generation_script failed",
+		},
+		{
+			name:   "script runs in the repo working directory",
+			script: "echo from-script > marker.txt",
+			assertDir: func(t *testing.T, repoDir string) {
+				t.Helper()
+				b, err := os.ReadFile(filepath.Join(repoDir, "marker.txt"))
+				if err != nil {
+					t.Fatalf("expected marker.txt in %s: %v", repoDir, err)
+				}
+				if strings.TrimSpace(string(b)) != "from-script" {
+					t.Fatalf("unexpected marker contents: %q", string(b))
+				}
+			},
+		},
+		{
+			name:   "honors working_directory subdir",
+			script: "echo nested > nested.txt",
+			assertDir: func(t *testing.T, repoDir string) {
+				t.Helper()
+				if _, err := os.Stat(filepath.Join(repoDir, "nested.txt")); err != nil {
+					t.Fatalf("expected nested.txt in working_directory %s: %v", repoDir, err)
+				}
+			},
+		},
+		{
+			name:    "multiline script with set -e fails fast",
+			script:  "set -e\nfalse\necho should-not-run",
+			wantErr: true,
+		},
+	}
+
+	t.Run("env is scrubbed of secrets", func(t *testing.T) {
+		repoDir := setupScriptEnv(t, "", `printenv > env.txt`)
+		t.Setenv("INPUT_GITHUB_ACCESS_TOKEN", "ghs_secrettoken")
+		t.Setenv("INPUT_SPEAKEASY_API_KEY", "sk_secretkey")
+		t.Setenv("GITHUB_TOKEN", "ghs_runnersecret")
+		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "oidcsecret")
+		t.Setenv("PATH", os.Getenv("PATH"))
+		t.Setenv("GITHUB_REPOSITORY", "owner/repo")
+
+		if err := runPostGenerationScript(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		envBytes, err := os.ReadFile(filepath.Join(repoDir, "env.txt"))
+		if err != nil {
+			t.Fatalf("read env.txt: %v", err)
+		}
+		envOut := string(envBytes)
+		for _, secret := range []string{"ghs_secrettoken", "sk_secretkey", "ghs_runnersecret", "oidcsecret", "INPUT_POST_GENERATION_SCRIPT", "INPUT_GITHUB_ACCESS_TOKEN", "INPUT_SPEAKEASY_API_KEY"} {
+			if strings.Contains(envOut, secret) {
+				t.Fatalf("script env leaked %q:\n%s", secret, envOut)
+			}
+		}
+		for _, allowed := range []string{"PATH=", "GITHUB_REPOSITORY=owner/repo"} {
+			if !strings.Contains(envOut, allowed) {
+				t.Fatalf("expected %q in script env:\n%s", allowed, envOut)
+			}
+		}
+	})
+
+	t.Run("cli_environment_variables are passed through", func(t *testing.T) {
+		repoDir := setupScriptEnv(t, "", `printenv > env.txt`)
+		t.Setenv("INPUT_CLI_ENVIRONMENT_VARIABLES", "MY_TOOL_VERSION=1.2.3\nFEATURE_FLAG=on")
+
+		if err := runPostGenerationScript(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		envOut, err := os.ReadFile(filepath.Join(repoDir, "env.txt"))
+		if err != nil {
+			t.Fatalf("read env.txt: %v", err)
+		}
+		for _, want := range []string{"MY_TOOL_VERSION=1.2.3", "FEATURE_FLAG=on"} {
+			if !strings.Contains(string(envOut), want) {
+				t.Fatalf("expected %q in script env:\n%s", want, envOut)
+			}
+		}
+	})
+
+	t.Run("timeout kills a long-running script", func(t *testing.T) {
+		setupScriptEnv(t, "", "sleep 30")
+
+		original := postGenerationScriptTimeout
+		postGenerationScriptTimeout = 100 * time.Millisecond
+		defer func() { postGenerationScriptTimeout = original }()
+
+		start := time.Now()
+		err := runPostGenerationScript()
+		elapsed := time.Since(start)
+
+		if err == nil {
+			t.Fatalf("expected timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "timeout") {
+			t.Fatalf("expected timeout error, got %q", err.Error())
+		}
+		if elapsed > 5*time.Second {
+			t.Fatalf("timeout did not kill the script promptly: took %s", elapsed)
+		}
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workingDir := ""
+			if tt.name == "honors working_directory subdir" {
+				workingDir = "sdks/python"
+			}
+			repoDir := setupScriptEnv(t, workingDir, tt.script)
+
+			err := runPostGenerationScript()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.assertDir != nil {
+				tt.assertDir(t, repoDir)
+			}
+		})
+	}
+}
+
+func setupScriptEnv(t *testing.T, workingDir, script string) string {
+	t.Helper()
+	workspace := t.TempDir()
+	repoDir := filepath.Join(workspace, "repo", workingDir)
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	t.Setenv("GITHUB_WORKSPACE", workspace)
+	t.Setenv("INPUT_WORKING_DIRECTORY", workingDir)
+	t.Setenv("INPUT_POST_GENERATION_SCRIPT", script)
+	return repoDir
+}

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -323,6 +323,10 @@ func GetWorkingDirectory() string {
 	return os.Getenv("INPUT_WORKING_DIRECTORY")
 }
 
+func GetPostGenerationScript() string {
+	return os.Getenv("INPUT_POST_GENERATION_SCRIPT")
+}
+
 func GetRepo() string {
 	if os.Getenv("INPUT_GITHUB_REPOSITORY") != "" {
 		return os.Getenv("INPUT_GITHUB_REPOSITORY")


### PR DESCRIPTION
## Summary
- Adds a new `post_generation_script` action input: an optional bash snippet that runs after a successful SDK generation and immediately before `CommitAndPush`, so any file mutations are included in the same commit/PR.
- Runs from the repo's `working_directory` via `bash -c` with a 10-minute timeout. Non-zero exit fails the run.
- The script's env is **scrubbed by default**: only an allowlist (PATH, HOME, locale, proxy, standard `GITHUB_*` and `RUNNER_*` vars) is passed through, plus anything the workflow author opts into via `cli_environment_variables`. Action secrets like `github_access_token` and `speakeasy_api_key` are NOT exposed to the script.
- Two call sites in `RunWorkflow`: the main `runRes.GenInfo != nil` path and the `sourcesOnly` path. Mutually exclusive.

## Why RFC
Posting as an RFC because the design choices are worth a sanity check before we encourage adoption:
1. **Env allowlist** — chose allowlist over denylist so any new secret env we add later is scrubbed by default. Tradeoff: a script that needs a non-listed var has to route through `cli_environment_variables`. Is the allowlist set right?
2. **Trust model** — script body comes from the workflow yaml, which the repo owner controls. We're not defending against a malicious workflow author (they already have shell). We *are* defending against a leaked/typoed script exfiltrating tokens.
3. **Timeout** — 10 minutes feels right for formatters / small codegen steps. Configurable later if needed.
4. **Behavior on `PushCodeSamplesOnly` and on the failure-path feature-branch commit** — script does NOT run on either path. The first doesn't commit; the second isn't a 'successful' generation. Both consistent with the docstring, but flagging in case reviewers disagree.

## Test plan
- [x] Unit tests in `internal/actions/run_post_generation_script_test.go`: empty/whitespace no-op, success, non-zero exit wrapping, runs in repo working dir, honors `working_directory` subdir, multiline `set -e`, timeout kills script, env is scrubbed of secrets (`GITHUB_TOKEN`, `INPUT_GITHUB_ACCESS_TOKEN`, `INPUT_SPEAKEASY_API_KEY`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, `INPUT_POST_GENERATION_SCRIPT`), `cli_environment_variables` pass through.
- [ ] Smoke test in a real customer workflow with a no-op script (`echo hello`) and a formatting script (e.g. `npm run format`).
- [ ] Verify the PR mode and direct mode both pick up script-authored file changes in the resulting commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)