### PR TITLE
fix: upload signed commit tree blobs separately

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/speakeasy-api/sdk-generation-action
 go 1.24.3
 
 require (
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.11.0
 	github.com/google/go-github/v63 v63.0.0
@@ -18,6 +19,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a
 	golang.org/x/oauth2 v0.11.0
+	golang.org/x/sync v0.17.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -28,7 +30,6 @@ require (
 	github.com/a8m/envsubst v1.4.3 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
-	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -57,7 +58,6 @@ require (
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/mod v0.15.0 // indirect
 	golang.org/x/net v0.42.0 // indirect
-	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
 	golang.org/x/tools v0.18.0 // indirect

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -16,8 +17,10 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -34,6 +37,7 @@ import (
 
 	"github.com/google/go-github/v63/github"
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/errgroup"
 )
 
 type Git struct {
@@ -753,6 +757,10 @@ func (g *Git) getOrCreateRef(commitRef string) (ref *github.Reference, err error
 
 type signedTreeBlobCreator func(ctx context.Context, path string, content []byte) (string, error)
 
+// maxConcurrentBlobUploads bounds parallel Git.CreateBlob calls so large SDK
+// repositories upload quickly without tripping GitHub's secondary rate limits.
+const maxConcurrentBlobUploads = 8
+
 // Generates the tree to commit based on the commit reference and source files. If doesn't exist on the remote
 // host, it will create and push it.
 func (g *Git) createAndPushTree(ref *github.Reference, sourceFiles git.Status) (tree *github.Tree, err error) {
@@ -762,18 +770,7 @@ func (g *Git) createAndPushTree(ref *github.Reference, sourceFiles git.Status) (
 	ctx := context.Background()
 
 	entries, stats, err := buildSignedCommitTreeEntries(ctx, sourceFiles, w.Filesystem.Root(), w.Filesystem.Join, func(ctx context.Context, path string, content []byte) (string, error) {
-		blob, _, err := g.client.Git.CreateBlob(ctx, owner, repo, &github.Blob{
-			Content:  github.String(base64.StdEncoding.EncodeToString(content)),
-			Encoding: github.String("base64"),
-		})
-		if err != nil {
-			return "", err
-		}
-		if blob.GetSHA() == "" {
-			return "", fmt.Errorf("empty blob SHA returned for %s", path)
-		}
-
-		return blob.GetSHA(), nil
+		return g.createBlobWithRetry(ctx, owner, repo, path, content)
 	})
 	if err != nil {
 		return nil, err
@@ -785,6 +782,102 @@ func (g *Git) createAndPushTree(ref *github.Reference, sourceFiles git.Status) (
 	return tree, err
 }
 
+// createBlobWithRetry uploads a single base64-encoded blob, retrying transient
+// GitHub failures (timeouts, 5xx, rate limiting) with exponential backoff.
+// Permanent failures (e.g. auth, 4xx) abort immediately.
+func (g *Git) createBlobWithRetry(ctx context.Context, owner, repo, path string, content []byte) (string, error) {
+	encoded := base64.StdEncoding.EncodeToString(content)
+
+	var sha string
+	op := func() error {
+		blob, resp, err := g.client.Git.CreateBlob(ctx, owner, repo, &github.Blob{
+			Content:  github.String(encoded),
+			Encoding: github.String("base64"),
+		})
+		if err != nil {
+			if !isRetryableBlobError(resp, err) {
+				return backoff.Permanent(err)
+			}
+			// When GitHub tells us how long to wait (rate limiting/abuse
+			// detection), honor that window before letting backoff retry.
+			// A short generic backoff would just burn the remaining retries
+			// against a limit that has not reset yet.
+			if wait, ok := rateLimitRetryAfter(err); ok {
+				if sleepErr := sleepWithContext(ctx, wait); sleepErr != nil {
+					return backoff.Permanent(sleepErr)
+				}
+			}
+			return err
+		}
+		if blob.GetSHA() == "" {
+			return backoff.Permanent(fmt.Errorf("empty blob SHA returned for %s", path))
+		}
+		sha = blob.GetSHA()
+		return nil
+	}
+
+	bo := backoff.WithContext(backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 3), ctx)
+	if err := backoff.Retry(op, bo); err != nil {
+		return "", err
+	}
+	return sha, nil
+}
+
+// isRetryableBlobError reports whether a Git.CreateBlob failure is worth
+// retrying. Transient conditions are network errors, GitHub rate limiting, and
+// 5xx/408/429 responses; everything else is treated as permanent.
+func isRetryableBlobError(resp *github.Response, err error) bool {
+	var rateErr *github.RateLimitError
+	var abuseErr *github.AbuseRateLimitError
+	if errors.As(err, &rateErr) || errors.As(err, &abuseErr) {
+		return true
+	}
+
+	if resp == nil || resp.Response == nil {
+		// No HTTP response usually means a network/transport error.
+		return true
+	}
+
+	switch {
+	case resp.StatusCode >= 500:
+		return true
+	case resp.StatusCode == http.StatusRequestTimeout, resp.StatusCode == http.StatusTooManyRequests:
+		return true
+	default:
+		return false
+	}
+}
+
+// rateLimitRetryAfter returns the server-indicated wait duration for a GitHub
+// rate-limit or abuse-detection error, if one is available and in the future.
+func rateLimitRetryAfter(err error) (time.Duration, bool) {
+	var abuseErr *github.AbuseRateLimitError
+	if errors.As(err, &abuseErr) && abuseErr.RetryAfter != nil && *abuseErr.RetryAfter > 0 {
+		return *abuseErr.RetryAfter, true
+	}
+
+	var rateErr *github.RateLimitError
+	if errors.As(err, &rateErr) {
+		if wait := time.Until(rateErr.Rate.Reset.Time); wait > 0 {
+			return wait, true
+		}
+	}
+
+	return 0, false
+}
+
+// sleepWithContext waits for d or until ctx is done, whichever comes first.
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 type signedTreeStats struct {
 	Deletes       int
 	BlobsUploaded int
@@ -792,42 +885,73 @@ type signedTreeStats struct {
 }
 
 func buildSignedCommitTreeEntries(ctx context.Context, sourceFiles git.Status, worktreeRoot string, join func(elem ...string) string, createBlob signedTreeBlobCreator) ([]*github.TreeEntry, signedTreeStats, error) {
-	entries := []*github.TreeEntry{}
-	stats := signedTreeStats{}
+	type uploadJob struct {
+		file    string
+		deleted bool
+	}
 
+	jobs := make([]uploadJob, 0, len(sourceFiles))
 	for file, fileStatus := range sourceFiles {
 		switch fileStatus.Staging {
 		case git.Unmodified, git.Untracked:
 			continue
 		case git.Deleted:
-			entries = append(entries, &github.TreeEntry{
-				Path: github.String(file),
+			jobs = append(jobs, uploadJob{file: file, deleted: true})
+		default:
+			jobs = append(jobs, uploadJob{file: file})
+		}
+	}
+
+	entries := make([]*github.TreeEntry, len(jobs))
+	stats := signedTreeStats{}
+	var mu sync.Mutex
+
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.SetLimit(maxConcurrentBlobUploads)
+
+	for i, job := range jobs {
+		i, job := i, job
+
+		if job.deleted {
+			entries[i] = &github.TreeEntry{
+				Path: github.String(job.file),
 				Mode: github.String("100644"),
-			})
+			}
+			mu.Lock()
 			stats.Deletes++
+			mu.Unlock()
 			continue
 		}
 
-		filePath := join(worktreeRoot, file)
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			logging.Info("Error getting file content: %v %s", err, filePath)
-			return nil, stats, err
-		}
+		eg.Go(func() error {
+			filePath := join(worktreeRoot, job.file)
+			content, err := os.ReadFile(filePath)
+			if err != nil {
+				logging.Info("Error getting file content: %v %s", err, filePath)
+				return err
+			}
 
-		sha, err := createBlob(ctx, file, content)
-		if err != nil {
-			return nil, stats, fmt.Errorf("error creating blob for %s: %w", file, err)
-		}
+			sha, err := createBlob(ctx, job.file, content)
+			if err != nil {
+				return fmt.Errorf("error creating blob for %s: %w", job.file, err)
+			}
 
-		entries = append(entries, &github.TreeEntry{
-			Path: github.String(file),
-			Type: github.String("blob"),
-			SHA:  github.String(sha),
-			Mode: github.String("100644"),
+			entries[i] = &github.TreeEntry{
+				Path: github.String(job.file),
+				Type: github.String("blob"),
+				SHA:  github.String(sha),
+				Mode: github.String("100644"),
+			}
+			mu.Lock()
+			stats.BlobsUploaded++
+			stats.BytesUploaded += len(content)
+			mu.Unlock()
+			return nil
 		})
-		stats.BlobsUploaded++
-		stats.BytesUploaded += len(content)
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, stats, err
 	}
 
 	return entries, stats, nil

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -750,34 +751,86 @@ func (g *Git) getOrCreateRef(commitRef string) (ref *github.Reference, err error
 	return ref, err
 }
 
+type signedTreeBlobCreator func(ctx context.Context, path string, content []byte) (string, error)
+
 // Generates the tree to commit based on the commit reference and source files. If doesn't exist on the remote
 // host, it will create and push it.
 func (g *Git) createAndPushTree(ref *github.Reference, sourceFiles git.Status) (tree *github.Tree, err error) {
 	_, githubRepoLocation := g.getRepoMetadata()
 	owner, repo := g.getOwnerAndRepo(githubRepoLocation)
 	w, _ := g.repo.Worktree()
+	ctx := context.Background()
 
-	entries := []*github.TreeEntry{}
-	for file, fileStatus := range sourceFiles {
-		if fileStatus.Staging != git.Unmodified && fileStatus.Staging != git.Untracked && fileStatus.Staging != git.Deleted {
-			filePath := w.Filesystem.Join(w.Filesystem.Root(), file)
-			content, err := os.ReadFile(filePath)
-			if err != nil {
-				fmt.Println("Error getting file content", err, filePath)
-				return nil, err
-			}
-
-			entries = append(entries, &github.TreeEntry{
-				Path:    github.String(file),
-				Type:    github.String("blob"),
-				Content: github.String(string(content)),
-				Mode:    github.String("100644"),
-			})
+	entries, stats, err := buildSignedCommitTreeEntries(ctx, sourceFiles, w.Filesystem.Root(), w.Filesystem.Join, func(ctx context.Context, path string, content []byte) (string, error) {
+		blob, _, err := g.client.Git.CreateBlob(ctx, owner, repo, &github.Blob{
+			Content:  github.String(base64.StdEncoding.EncodeToString(content)),
+			Encoding: github.String("base64"),
+		})
+		if err != nil {
+			return "", err
 		}
+		if blob.GetSHA() == "" {
+			return "", fmt.Errorf("empty blob SHA returned for %s", path)
+		}
+
+		return blob.GetSHA(), nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	tree, _, err = g.client.Git.CreateTree(context.Background(), owner, repo, *ref.Object.SHA, entries)
+	logging.Info("Creating signed commit tree with %d changed entries (%d deletes), uploaded %d bytes across %d blobs", len(entries), stats.Deletes, stats.BytesUploaded, stats.BlobsUploaded)
+
+	tree, _, err = g.client.Git.CreateTree(ctx, owner, repo, *ref.Object.SHA, entries)
 	return tree, err
+}
+
+type signedTreeStats struct {
+	Deletes       int
+	BlobsUploaded int
+	BytesUploaded int
+}
+
+func buildSignedCommitTreeEntries(ctx context.Context, sourceFiles git.Status, worktreeRoot string, join func(elem ...string) string, createBlob signedTreeBlobCreator) ([]*github.TreeEntry, signedTreeStats, error) {
+	entries := []*github.TreeEntry{}
+	stats := signedTreeStats{}
+
+	for file, fileStatus := range sourceFiles {
+		switch fileStatus.Staging {
+		case git.Unmodified, git.Untracked:
+			continue
+		case git.Deleted:
+			entries = append(entries, &github.TreeEntry{
+				Path: github.String(file),
+				Mode: github.String("100644"),
+			})
+			stats.Deletes++
+			continue
+		}
+
+		filePath := join(worktreeRoot, file)
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			logging.Info("Error getting file content: %v %s", err, filePath)
+			return nil, stats, err
+		}
+
+		sha, err := createBlob(ctx, file, content)
+		if err != nil {
+			return nil, stats, fmt.Errorf("error creating blob for %s: %w", file, err)
+		}
+
+		entries = append(entries, &github.TreeEntry{
+			Path: github.String(file),
+			Type: github.String("blob"),
+			SHA:  github.String(sha),
+			Mode: github.String("100644"),
+		})
+		stats.BlobsUploaded++
+		stats.BytesUploaded += len(content)
+	}
+
+	return entries, stats, nil
 }
 
 func (g *Git) Add(arg string) error {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -143,9 +146,12 @@ func TestBuildSignedCommitTreeEntries_UsesBlobSHAForChangedFiles(t *testing.T) {
 		"ignored.md": {Staging: git.Unmodified, Worktree: git.Modified},
 	}
 	createdBlobs := map[string]string{}
+	var createdBlobsMu sync.Mutex
 
 	entries, stats, err := buildSignedCommitTreeEntries(context.Background(), status, dir, filepath.Join, func(ctx context.Context, path string, content []byte) (string, error) {
+		createdBlobsMu.Lock()
 		createdBlobs[path] = string(content)
+		createdBlobsMu.Unlock()
 		return path + "-blob-sha", nil
 	})
 
@@ -196,6 +202,174 @@ func TestBuildSignedCommitTreeEntries_RepresentsDeletedFiles(t *testing.T) {
 	payload, err := json.Marshal(entry)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"sha":null,"path":"removed.md","mode":"100644"}`, string(payload))
+}
+
+func TestBuildSignedCommitTreeEntries_UploadsConcurrentlyAndPreservesEntries(t *testing.T) {
+	dir := t.TempDir()
+	const fileCount = 50
+
+	status := git.Status{}
+	want := map[string]string{}
+	for i := 0; i < fileCount; i++ {
+		name := fmt.Sprintf("file-%02d.txt", i)
+		content := fmt.Sprintf("content-%02d", i)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+		status[name] = &git.FileStatus{Staging: git.Modified, Worktree: git.Unmodified}
+		want[name] = content
+	}
+
+	var (
+		mu         sync.Mutex
+		concurrent int32
+		maxSeen    int32
+		uploaded   = map[string]string{}
+	)
+
+	entries, stats, err := buildSignedCommitTreeEntries(context.Background(), status, dir, filepath.Join, func(ctx context.Context, path string, content []byte) (string, error) {
+		cur := atomic.AddInt32(&concurrent, 1)
+		for {
+			prev := atomic.LoadInt32(&maxSeen)
+			if cur <= prev || atomic.CompareAndSwapInt32(&maxSeen, prev, cur) {
+				break
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+		atomic.AddInt32(&concurrent, -1)
+
+		mu.Lock()
+		uploaded[path] = string(content)
+		mu.Unlock()
+		return path + "-sha", nil
+	})
+
+	require.NoError(t, err)
+	require.Len(t, entries, fileCount)
+	require.Equal(t, want, uploaded)
+	require.Equal(t, fileCount, stats.BlobsUploaded)
+	require.LessOrEqual(t, int(maxSeen), maxConcurrentBlobUploads, "blob uploads must respect the concurrency limit")
+	require.Greater(t, int(maxSeen), 1, "blob uploads should run concurrently")
+
+	for _, entry := range entries {
+		require.NotNil(t, entry, "every job slot must be populated")
+		require.Equal(t, entry.GetPath()+"-sha", entry.GetSHA())
+		require.Equal(t, "blob", entry.GetType())
+	}
+}
+
+func TestBuildSignedCommitTreeEntries_PropagatesBlobError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), 0o600))
+
+	status := git.Status{
+		"a.txt": {Staging: git.Modified, Worktree: git.Unmodified},
+	}
+
+	_, _, err := buildSignedCommitTreeEntries(context.Background(), status, dir, filepath.Join, func(ctx context.Context, path string, content []byte) (string, error) {
+		return "", fmt.Errorf("boom")
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error creating blob for a.txt")
+	require.Contains(t, err.Error(), "boom")
+}
+
+func TestIsRetryableBlobError(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *github.Response
+		err  error
+		want bool
+	}{
+		{
+			name: "rate limit error is retryable",
+			err:  &github.RateLimitError{},
+			want: true,
+		},
+		{
+			name: "abuse rate limit error is retryable",
+			err:  &github.AbuseRateLimitError{},
+			want: true,
+		},
+		{
+			name: "nil response (transport error) is retryable",
+			resp: nil,
+			err:  fmt.Errorf("connection reset"),
+			want: true,
+		},
+		{
+			name: "500 is retryable",
+			resp: &github.Response{Response: &http.Response{StatusCode: http.StatusInternalServerError}},
+			err:  fmt.Errorf("server error"),
+			want: true,
+		},
+		{
+			name: "408 is retryable",
+			resp: &github.Response{Response: &http.Response{StatusCode: http.StatusRequestTimeout}},
+			err:  fmt.Errorf("timeout"),
+			want: true,
+		},
+		{
+			name: "429 is retryable",
+			resp: &github.Response{Response: &http.Response{StatusCode: http.StatusTooManyRequests}},
+			err:  fmt.Errorf("too many requests"),
+			want: true,
+		},
+		{
+			name: "422 is permanent",
+			resp: &github.Response{Response: &http.Response{StatusCode: http.StatusUnprocessableEntity}},
+			err:  fmt.Errorf("unprocessable"),
+			want: false,
+		},
+		{
+			name: "401 is permanent",
+			resp: &github.Response{Response: &http.Response{StatusCode: http.StatusUnauthorized}},
+			err:  fmt.Errorf("unauthorized"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isRetryableBlobError(tt.resp, tt.err))
+		})
+	}
+}
+
+func TestRateLimitRetryAfter(t *testing.T) {
+	t.Run("abuse RetryAfter is used", func(t *testing.T) {
+		retryAfter := 30 * time.Second
+		wait, ok := rateLimitRetryAfter(&github.AbuseRateLimitError{RetryAfter: &retryAfter})
+		require.True(t, ok)
+		require.Equal(t, retryAfter, wait)
+	})
+
+	t.Run("future rate limit reset is used", func(t *testing.T) {
+		reset := time.Now().Add(time.Minute)
+		wait, ok := rateLimitRetryAfter(&github.RateLimitError{
+			Rate: github.Rate{Reset: github.Timestamp{Time: reset}},
+		})
+		require.True(t, ok)
+		require.Greater(t, wait, time.Duration(0))
+		require.LessOrEqual(t, wait, time.Minute)
+	})
+
+	t.Run("past rate limit reset is ignored", func(t *testing.T) {
+		_, ok := rateLimitRetryAfter(&github.RateLimitError{
+			Rate: github.Rate{Reset: github.Timestamp{Time: time.Now().Add(-time.Minute)}},
+		})
+		require.False(t, ok)
+	})
+
+	t.Run("non rate-limit error returns false", func(t *testing.T) {
+		_, ok := rateLimitRetryAfter(fmt.Errorf("boom"))
+		require.False(t, ok)
+	})
+}
+
+func TestSleepWithContext_CancelledReturnsErr(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, sleepWithContext(ctx, time.Hour), context.Canceled)
 }
 
 func TestGit_CheckDirDirty_IgnoredFiles(t *testing.T) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -128,6 +130,72 @@ func TestGit_CheckDirDirty(t *testing.T) {
 
 	require.Equal(t, `new file found: []string{"dirty-file"}`, str)
 	require.True(t, dirty, "expected the directory to be dirty")
+}
+
+func TestBuildSignedCommitTreeEntries_UsesBlobSHAForChangedFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("updated content"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new.md"), []byte("new content"), 0o600))
+
+	status := git.Status{
+		"README.md":  {Staging: git.Modified, Worktree: git.Unmodified},
+		"new.md":     {Staging: git.Added, Worktree: git.Unmodified},
+		"ignored.md": {Staging: git.Unmodified, Worktree: git.Modified},
+	}
+	createdBlobs := map[string]string{}
+
+	entries, stats, err := buildSignedCommitTreeEntries(context.Background(), status, dir, filepath.Join, func(ctx context.Context, path string, content []byte) (string, error) {
+		createdBlobs[path] = string(content)
+		return path + "-blob-sha", nil
+	})
+
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	require.Equal(t, map[string]string{
+		"README.md": "updated content",
+		"new.md":    "new content",
+	}, createdBlobs)
+	require.Equal(t, signedTreeStats{BlobsUploaded: 2, BytesUploaded: len("updated content") + len("new content")}, stats)
+
+	entriesByPath := map[string]*github.TreeEntry{}
+	for _, entry := range entries {
+		entriesByPath[entry.GetPath()] = entry
+	}
+
+	for _, path := range []string{"README.md", "new.md"} {
+		entry := entriesByPath[path]
+		require.NotNil(t, entry)
+		require.Equal(t, "blob", entry.GetType())
+		require.Equal(t, "100644", entry.GetMode())
+		require.Equal(t, path+"-blob-sha", entry.GetSHA())
+		require.Nil(t, entry.Content, "changed files should reference uploaded blob SHAs instead of inline content")
+	}
+}
+
+func TestBuildSignedCommitTreeEntries_RepresentsDeletedFiles(t *testing.T) {
+	status := git.Status{
+		"removed.md": {Staging: git.Deleted, Worktree: git.Deleted},
+	}
+
+	entries, stats, err := buildSignedCommitTreeEntries(context.Background(), status, t.TempDir(), filepath.Join, func(ctx context.Context, path string, content []byte) (string, error) {
+		t.Fatalf("deleted files should not upload blobs")
+		return "", nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, signedTreeStats{Deletes: 1}, stats)
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	require.Equal(t, "removed.md", entry.GetPath())
+	require.Equal(t, "100644", entry.GetMode())
+	require.Empty(t, entry.GetSHA())
+	require.Nil(t, entry.SHA)
+	require.Nil(t, entry.Content)
+
+	payload, err := json.Marshal(entry)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"sha":null,"path":"removed.md","mode":"100644"}`, string(payload))
 }
 
 func TestGit_CheckDirDirty_IgnoredFiles(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix signed-commit tree creation for large generated repositories by moving changed file contents out of the `CreateTree` request body.

## Background

Signed commits use the GitHub Git API instead of the normal go-git commit/push path. The previous signed path built one `Git.CreateTree` request containing every changed file's full content inline in each tree entry.

For large SDK repositories, this can make the tree request too large for GitHub to process reliably. The observed customer failure happened after generation succeeded, while committing and pushing changes:

```text
error creating new tree: POST https://api.github.com/repos/vercel/sdk/git/trees: 422 Sorry, your request timed out. It's likely that your input was too large to process...
```

The same path also skipped staged deleted files, so signed commits could fail to remove files that generation deleted.

## Fix

- Upload each added/modified staged file with `Git.CreateBlob` first.
- Build the signed commit tree using blob `SHA` references instead of inline `Content`.
- Encode blob uploads as base64 so generated binary files are handled safely.
- Add explicit delete tree entries for staged `git.Deleted` paths with no `SHA` or `Content`, which go-github marshals as `sha:null` for GitHub's delete semantics.
- Add logging for changed entry count, delete count, uploaded byte count, and uploaded blob count.
- Add focused helper tests for blob-SHA tree entries and delete payload serialization.

Unsigned commits still use the existing go-git commit/push behavior unchanged.

## Validation

- `gofmt -w internal/git/git.go internal/git/git_test.go`
- `go test ./internal/git`
