### PR TITLE
fix: retry signed commit tree creation

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -778,8 +778,66 @@ func (g *Git) createAndPushTree(ref *github.Reference, sourceFiles git.Status) (
 
 	logging.Info("Creating signed commit tree with %d changed entries (%d deletes), uploaded %d bytes across %d blobs", len(entries), stats.Deletes, stats.BytesUploaded, stats.BlobsUploaded)
 
-	tree, _, err = g.client.Git.CreateTree(ctx, owner, repo, *ref.Object.SHA, entries)
-	return tree, err
+	return g.createTreeWithRetry(ctx, owner, repo, *ref.Object.SHA, entries)
+}
+
+// createTreeWithRetry creates a git tree, retrying transient GitHub failures.
+// Large generated SDK commits can produce thousands of tree entries; GitHub's
+// tree API may occasionally return transient 5xx responses after all blobs have
+// already been uploaded, so retrying avoids wasting the whole generation run.
+func (g *Git) createTreeWithRetry(ctx context.Context, owner, repo, baseTree string, entries []*github.TreeEntry) (*github.Tree, error) {
+	var tree *github.Tree
+	op := func() error {
+		createdTree, resp, err := g.client.Git.CreateTree(ctx, owner, repo, baseTree, entries)
+		if err != nil {
+			if !isRetryableGitHubError(resp, err) {
+				return backoff.Permanent(err)
+			}
+			if wait, ok := rateLimitRetryAfter(err); ok {
+				if sleepErr := sleepWithContext(ctx, wait); sleepErr != nil {
+					return backoff.Permanent(sleepErr)
+				}
+			}
+			return err
+		}
+		if createdTree.GetSHA() == "" {
+			return backoff.Permanent(errors.New("empty tree SHA returned"))
+		}
+		tree = createdTree
+		return nil
+	}
+
+	bo := backoff.WithContext(backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 3), ctx)
+	if err := backoff.Retry(op, bo); err != nil {
+		return nil, formatCreateTreeError(err, baseTree, len(entries))
+	}
+	return tree, nil
+}
+
+func formatCreateTreeError(err error, baseTree string, entryCount int) error {
+	message := fmt.Sprintf("create tree failed after retries (base_tree=%s, entries=%d): %v", baseTree, entryCount, err)
+
+	var githubErr *github.ErrorResponse
+	if errors.As(err, &githubErr) {
+		details := []string{}
+		if githubErr.Response != nil {
+			details = append(details, fmt.Sprintf("status=%d", githubErr.Response.StatusCode))
+		}
+		if githubErr.Message != "" {
+			details = append(details, fmt.Sprintf("message=%q", githubErr.Message))
+		}
+		if len(githubErr.Errors) > 0 {
+			details = append(details, fmt.Sprintf("errors=%+v", githubErr.Errors))
+		}
+		if githubErr.DocumentationURL != "" {
+			details = append(details, fmt.Sprintf("documentation_url=%s", githubErr.DocumentationURL))
+		}
+		if len(details) > 0 {
+			message = fmt.Sprintf("%s (%s)", message, strings.Join(details, ", "))
+		}
+	}
+
+	return fmt.Errorf("%s", message)
 }
 
 // createBlobWithRetry uploads a single base64-encoded blob, retrying transient
@@ -827,6 +885,10 @@ func (g *Git) createBlobWithRetry(ctx context.Context, owner, repo, path string,
 // retrying. Transient conditions are network errors, GitHub rate limiting, and
 // 5xx/408/429 responses; everything else is treated as permanent.
 func isRetryableBlobError(resp *github.Response, err error) bool {
+	return isRetryableGitHubError(resp, err)
+}
+
+func isRetryableGitHubError(resp *github.Response, err error) bool {
 	var rateErr *github.RateLimitError
 	var abuseErr *github.AbuseRateLimitError
 	if errors.As(err, &rateErr) || errors.As(err, &abuseErr) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -271,6 +273,90 @@ func TestBuildSignedCommitTreeEntries_PropagatesBlobError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error creating blob for a.txt")
 	require.Contains(t, err.Error(), "boom")
+}
+
+func TestCreateTreeWithRetry_RetriesTransientGitHubErrors(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/repos/owner/repo/git/trees", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+
+		if requests.Add(1) == 1 {
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"sha":"tree-sha"}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	baseURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+
+	client := github.NewClient(server.Client())
+	client.BaseURL = baseURL
+
+	g := &Git{client: client}
+	tree, err := g.createTreeWithRetry(context.Background(), "owner", "repo", "base-sha", []*github.TreeEntry{
+		{Path: github.String("file.txt"), Mode: github.String("100644"), Type: github.String("blob"), SHA: github.String("blob-sha")},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "tree-sha", tree.GetSHA())
+	require.Equal(t, int32(2), requests.Load())
+}
+
+func TestCreateTreeWithRetry_DoesNotRetryPermanentGitHubErrors(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Error(w, "validation failed", http.StatusUnprocessableEntity)
+	}))
+	defer server.Close()
+
+	baseURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+
+	client := github.NewClient(server.Client())
+	client.BaseURL = baseURL
+
+	g := &Git{client: client}
+	_, err = g.createTreeWithRetry(context.Background(), "owner", "repo", "base-sha", nil)
+
+	require.Error(t, err)
+	require.Equal(t, int32(1), requests.Load())
+}
+
+func TestCreateTreeWithRetry_ReturnsErrorAfterTransientRetriesAreExhausted(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, err := w.Write([]byte(`{"message":"Sorry, your request timed out. It's likely that your input was too large to process.","documentation_url":"https://docs.github.com/rest/git/trees#create-a-tree"}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	baseURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+
+	client := github.NewClient(server.Client())
+	client.BaseURL = baseURL
+
+	g := &Git{client: client}
+	_, err = g.createTreeWithRetry(context.Background(), "owner", "repo", "base-sha", nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "create tree failed after retries")
+	require.Contains(t, err.Error(), "base_tree=base-sha")
+	require.Contains(t, err.Error(), "entries=0")
+	require.Contains(t, err.Error(), "status=502")
+	require.Contains(t, err.Error(), "input was too large")
+	require.Contains(t, err.Error(), "documentation_url=https://docs.github.com/rest/git/trees#create-a-tree")
+	require.Equal(t, int32(4), requests.Load())
 }
 
 func TestIsRetryableBlobError(t *testing.T) {


### PR DESCRIPTION
## Why

Large signed SDK regeneration commits can fail during GitHub tree creation with transient or timeout-style `502` responses from `POST /git/trees`. When this happens after blob uploads complete, the action currently fails the whole run without retrying or surfacing useful GitHub error details.

## What changed

- Retry signed commit `CreateTree` calls using the same transient GitHub error policy as blob uploads.
- Preserve permanent failure behavior for validation/auth-style errors.
- Include base tree, entry count, status, message, GitHub errors, and docs URL when tree creation still fails after retries.
- Add unit coverage for retry success, permanent no-retry behavior, and retry exhaustion with GitHub-style error output.

## Testing

- `go test ./internal/git`
- `go test ./...`
