### PR TITLE
ci: pin internal workflow refs

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -181,7 +181,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - id: release
         uses: ./_speakeasy
@@ -215,7 +215,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"
   publish-pypi:
@@ -232,7 +232,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - name: Set up Python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
@@ -283,7 +283,7 @@ jobs:
           registry_name: "pypi"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -306,7 +306,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"
   publish-npm:
@@ -323,7 +323,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -402,7 +402,7 @@ jobs:
           registry_name: "npm"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -425,7 +425,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"
   publish-npm-mcp:
@@ -442,7 +442,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -529,7 +529,7 @@ jobs:
           registry_name: "npm"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2.5.0
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -552,7 +552,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "mcp"
   publish-mcp-registry:
@@ -610,7 +610,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
@@ -652,7 +652,7 @@ jobs:
           registry_name: "sonatype"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -675,7 +675,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"
   publish-packagist:
@@ -692,7 +692,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - name: Publish
         uses: speakeasy-api/packagist-update@5e2c88e23c7d21e40c7a02a3b252a749b351eb2f # support-github-creation
@@ -714,7 +714,7 @@ jobs:
           registry_name: "packagist"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -737,7 +737,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"
   publish-nuget:
@@ -754,7 +754,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - name: Setup dotnet
         uses: actions/setup-dotnet@55ec9447dda3d1cf6bd587150f3262f30ee10815 # v3
@@ -775,7 +775,7 @@ jobs:
           registry_name: "nuget"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -798,7 +798,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"
   publish-cli:
@@ -818,7 +818,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - name: Setup Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v5.0.2
@@ -858,7 +858,7 @@ jobs:
           registry_name: "go"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -881,7 +881,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"
   publish-terraform:
@@ -894,7 +894,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4
@@ -930,7 +930,7 @@ jobs:
           registry_name: "terraform"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -953,7 +953,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"
   publish-gems:
@@ -970,7 +970,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - name: Set up Ruby
         uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
@@ -1001,7 +1001,7 @@ jobs:
           registry_name: "gems"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -1024,6 +1024,6 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"

--- a/.github/workflows/sdk-test.yaml
+++ b/.github/workflows/sdk-test.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - name: Set dynamic environment variables
         if: inputs.env_vars != ''
@@ -66,7 +66,7 @@ jobs:
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
           github_access_token: ${{ secrets.github_access_token }}
         env:
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - name: Upload test reports
         if: always() && steps.check_commit.outputs.run_tests == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - id: apply-tags
         name: Apply Tags
@@ -48,4 +48,4 @@ jobs:
           speakeasy_api_key: ${{ secrets.speakeasy_api_key }}
           github_access_token: ${{ secrets.github_access_token }}
         env:
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -237,7 +237,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - id: run-workflow
         name: Run Generation Workflow
@@ -294,7 +294,7 @@ jobs:
         env:
           GH_ACTION_RESULT: ${{ job.status }}
           RESOLVED_SPEAKEASY_VERSION: ${{ steps.run-workflow.outputs.resolved_speakeasy_version }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
   publish-pypi:
     if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.run-workflow.outputs.python_regenerated == 'true' && needs.run-workflow.outputs.publish_python == 'true' && inputs.mode != 'pr' }}
@@ -312,7 +312,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - name: Set up Python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
@@ -374,7 +374,7 @@ jobs:
           registry_name: "pypi"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -398,7 +398,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"
   publish-npm:
@@ -417,7 +417,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -461,7 +461,7 @@ jobs:
           registry_name: "npm"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -485,7 +485,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"
   publish-java:
@@ -504,7 +504,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
@@ -546,7 +546,7 @@ jobs:
           registry_name: "sonatype"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -570,7 +570,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"
   publish-gems:
@@ -589,7 +589,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - name: Set up Ruby
         uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
@@ -620,7 +620,7 @@ jobs:
           registry_name: "gems"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -644,7 +644,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"
   publish-nuget:
@@ -663,7 +663,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - name: Setup dotnet
         uses: actions/setup-dotnet@55ec9447dda3d1cf6bd587150f3262f30ee10815 # v3
@@ -684,7 +684,7 @@ jobs:
           registry_name: "nuget"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -708,7 +708,7 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"
   publish-packagist:
@@ -727,7 +727,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: speakeasy-api/sdk-generation-action
-          ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+          ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           path: _speakeasy
       - name: Publish
         uses: speakeasy-api/packagist-update@5e2c88e23c7d21e40c7a02a3b252a749b351eb2f # support-github-creation
@@ -749,7 +749,7 @@ jobs:
           registry_name: "packagist"
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
       - uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
         if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
@@ -773,6 +773,6 @@ jobs:
           speakeasy_server_url: ${{ inputs.speakeasy_server_url }}
         env:
           GH_ACTION_RESULT: ${{ job.status }}
-          GH_ACTION_VERSION: 34775c77358723ceed27ee8283cd9441e5a614e9
+          GH_ACTION_VERSION: 8b90b1b452591f99c554c93c0ad0dca5318eff26
           GH_ACTION_STEP: ${{ github.job }}
           TARGET_TYPE: "sdk"

--- a/publish-pypi/action.yml
+++ b/publish-pypi/action.yml
@@ -33,7 +33,7 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         repository: speakeasy-api/sdk-generation-action
-        ref: 34775c77358723ceed27ee8283cd9441e5a614e9
+        ref: 8b90b1b452591f99c554c93c0ad0dca5318eff26
         path: _speakeasy
     - name: Set up Python
       uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0


### PR DESCRIPTION
## Why

Follow-up to #334 and the release process. Internal workflow and composite-action refs need to point at the latest `main` SHA before creating the GitHub release.

## What changed

- Pinned internal `speakeasy-api/sdk-generation-action` checkout refs to `8b90b1b452591f99c554c93c0ad0dca5318eff26`.
- Updated matching `GH_ACTION_VERSION` environment values to the same SHA.

## Review notes

- Generated from the release process in `README.md`; `./scripts/update-refs.sh` could not run locally because `yq` is not installed, so the same SHA replacement was applied directly to the script-targeted files.

## Testing

- `go test ./...`
